### PR TITLE
Remove extra `dmc.Text`

### DIFF
--- a/docs/card/border.py
+++ b/docs/card/border.py
@@ -30,15 +30,11 @@ component = dmc.Card(
         dmc.Text(
             children=[
                 dmc.Text(
-                    [
-                        dmc.Text(
-                            "200+ images uploaded",
-                            color="blue",
-                            style={"display": "inline"},
-                        ),
-                        " since last visit, review them to select which one should be added to your gallery",
-                    ]
+                    "200+ images uploaded",
+                    color="blue",
+                    style={"display": "inline"},
                 ),
+                " since last visit, review them to select which one should be added to your gallery",
             ],
             mt="sm",
             color="dimmed",


### PR DESCRIPTION
I think there's a redundant `dmc.Text` here. In a project I'm working on, I'm able to get inline text styles with:

```python
dmc.Text(
    children=[
        dmc.Text("some text", style={"display": "inline"}),
        " and some more text."
    ]
)
```