### PR TITLE
Added docs for  `DatePicker`, `DatePickerInput` and `DatesProvider`

### DIFF
--- a/docs/datepicker/amount.py
+++ b/docs/datepicker/amount.py
@@ -1,0 +1,8 @@
+from datetime import datetime, timedelta
+
+import dash_mantine_components as dmc
+
+component = dmc.DatePicker(
+    value=datetime.now().date(),
+    numberOfColumns=2,
+)

--- a/docs/datepicker/datepicker.md
+++ b/docs/datepicker/datepicker.md
@@ -1,0 +1,136 @@
+---
+name: DatePicker
+description: Inline date, multiple dates and dates range picker. Helps you easily switch between different months, years along with locale support.
+endpoint: /components/datapicker
+package: dash_mantine_components
+---
+
+.. toc::
+
+.. admonition::Note
+    :color: yellow
+    :icon: radix-icons:info-circled
+    To include an Input field for the DatePicker, use DatePickerInput.  The DatePickerInput supports all props for DatePicker shown on this page.
+
+### Simple Example
+
+.. exec::docs.datepicker.simple
+
+
+
+
+### Allow deselect
+Set `allowDeselect` to allow user to deselect current selected date by clicking on it. `allowDeselect` is disregarded when type prop is range or multiple. When date is deselected the `value` will be None.
+
+
+.. exec::docs.datepicker.deselect
+
+
+
+### Multiple dates
+Set type="multiple" to allow user to pick multiple dates.
+
+.. exec::docs.datepicker.multiple
+
+
+### Dates range
+Set type="range" to allow user to pick dates range:
+
+.. exec::docs.datepicker.range
+
+### Disabled dates
+Use the `disabledDates` prop to specify days that should be disabled.
+
+.. exec::docs.datepicker.disabled_dates
+
+### Single date in range
+By default, it is not allowed to select single date as range – when user clicks the same date second time it is deselected. To change this behavior set `allowSingleDateInRange` prop. `allowSingleDateInRange` is ignored when `type` prop is not `range`.
+
+.. exec::docs.datepicker.range_single
+
+### Level
+Set `level` prop to configure initial level that will be displayed.
+
+.. exec::docs.datepicker.default_level
+
+### Hide outside dates
+Set `hideOutsideDates` prop to remove all dates that do not belong to the current month.
+
+.. exec::docs.datepicker.hide_outside
+
+### First day of week
+Set `firstDayOfWeek` prop to configure first day of week. The prop accepts number from 0 to 6, where 0 is Sunday and 6 is Saturday. Default value is 1 – Monday. You can also configure this option for all components with DatesProvider.
+
+.. exec::docs.datepicker.first_day_of_week
+
+### Hide weekdays
+Set `hideWeekdays` prop to hide weekdays names.
+
+.. exec::docs.datepicker.hide_weekdays
+
+### Weekend days
+Use `weekendDays` prop to configure weekend days. The prop accepts an array of numbers from 0 to 6, where 0 is Sunday and 6 is Saturday. Default value is [0, 6] – Saturday and Sunday. You can also configure this option for all components with DatesProvider.
+
+.. exec::docs.datepicker.weekend_days
+
+### Min and max date
+Set `minDate` and `maxDate` props to define min and max dates. If previous/next page is not available then corresponding control will be disabled.
+
+
+.. exec::docs.datepicker.min_max
+
+
+### Number of columns
+
+Set `numberOfColumns` prop to define number of pickers that will be rendered side by side.
+
+.. exec::docs.datepicker.amount
+
+### Max level
+Use the `maxLevel` prop to set the max level that user can go up to (decade, year, month), defaults to decade.
+
+.. exec::docs.datepicker.max_level
+
+### Size
+
+.. exec::docs.datepicker.size
+    :code: false
+
+### Change year and months controls format
+Use `yearsListFormat` and `monthsListFormat` props to change [dayjs](https://day.js.org/docs/en/display/format) format of year/month controls:
+
+.. exec::docs.datepicker.year_month_controls
+
+### Change label format
+Use decadeLabelFormat, yearLabelFormat and monthLabelFormat props to change [dayjs](https://day.js.org/docs/en/display/format) format of decade/year label:
+
+
+.. exec::docs.datepicker.label_format
+
+### Localization
+
+DatePickerInput component uses `dayjs` behind the scenes. So you can easily customize locale by including required locale data
+and setting the `locale` prop. Make sure to include proper localization file from `dayjs` library.
+
+Wrap the DatePickerInput with the DatesProvider.  See the DatesProvider component for more details.
+
+```python
+from dash import Dash
+
+scripts = [
+    "https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.8/dayjs.min.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.8/locale/fr.min.js",
+]
+
+app = Dash(__name__, external_scripts=scripts)
+```
+
+.. exec::docs.datepicker.locale
+
+
+
+### Keyword Arguments
+
+#### DatePicker
+
+.. kwargs::DatePicker

--- a/docs/datepicker/default_level.py
+++ b/docs/datepicker/default_level.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.Stack(
+    [
+        dmc.DatePicker(
+            value=datetime.now().date(),
+            level="decade"
+        ),
+        dmc.DatePicker(
+            value=datetime.now().date(),
+            level="year"
+        )
+    ]
+)

--- a/docs/datepicker/deselect.py
+++ b/docs/datepicker/deselect.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.DatePicker(
+    value=datetime.now().date(),
+    allowDeselect=True,
+)

--- a/docs/datepicker/disabled_dates.py
+++ b/docs/datepicker/disabled_dates.py
@@ -1,0 +1,11 @@
+from datetime import datetime, timedelta
+
+import dash_mantine_components as dmc
+
+today = datetime.now().date()
+
+component = dmc.DatePicker(
+    value=today,
+    disabledDates=[today + timedelta(days=1), today + timedelta(days=3)],
+)
+

--- a/docs/datepicker/first_day_of_week.py
+++ b/docs/datepicker/first_day_of_week.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.Stack(
+    [
+        dmc.DatePicker(
+            value=datetime.now().date(),
+            firstDayOfWeek=0
+        ),
+        dmc.DatePicker(
+            value=datetime.now().date(),
+            firstDayOfWeek=6
+        )
+    ]
+)

--- a/docs/datepicker/hide_outside.py
+++ b/docs/datepicker/hide_outside.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.DatePicker(
+    value=datetime.now().date(),
+    hideOutsideDates=True
+)

--- a/docs/datepicker/hide_weekdays.py
+++ b/docs/datepicker/hide_weekdays.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.DatePicker(
+    value=datetime.now().date(),
+    hideWeekdays=True
+)

--- a/docs/datepicker/label_format.py
+++ b/docs/datepicker/label_format.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.DatePicker(
+    value=datetime.now().date(),
+    decadeLabelFormat = "YY",
+    yearLabelFormat = "YYYY [year]",
+    monthLabelFormat = "MM/YY"
+)

--- a/docs/datepicker/locale.py
+++ b/docs/datepicker/locale.py
@@ -1,0 +1,9 @@
+import dash_mantine_components as dmc
+
+component = dmc.DatesProvider(
+    dmc.DatePicker(
+        id="fr-date-picker",
+        style={"width": 200},
+    ),
+    settings={"locale": "fr"}
+)

--- a/docs/datepicker/max_level.py
+++ b/docs/datepicker/max_level.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.Stack(
+    [
+        dmc.DatePicker(
+            value=datetime.now().date(),
+            maxLevel="year"
+        ),
+        dmc.DatePicker(
+            value=datetime.now().date(),
+            maxLevel="month"
+        )
+    ]
+)

--- a/docs/datepicker/min_max.py
+++ b/docs/datepicker/min_max.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+import dash_mantine_components as dmc
+
+component =dmc.DatePicker(
+    minDate=date(2023, 8, 1),
+    maxDate=date(2023, 8, 15),
+    value="2023-08-11",
+    # defaultDate = "2023-08"    Need to add this prop to display correct month at start
+)

--- a/docs/datepicker/multiple.py
+++ b/docs/datepicker/multiple.py
@@ -1,0 +1,28 @@
+from datetime import datetime, date, timedelta
+
+import dash_mantine_components as dmc
+from dash import Input, Output, html, callback, no_update
+
+
+component = html.Div(
+    [
+        dmc.DatePicker(
+            id="date-picker-multiple",
+            minDate=date(2020, 8, 5),
+            value=[datetime.now().date(), datetime.now().date() + timedelta(days=5)],
+            type="multiple",
+        ),
+        dmc.Space(h=10),
+        dmc.Text(id="selected-date-multiple"),
+    ]
+)
+
+
+@callback(Output("selected-date-multiple", "children"), Input("date-picker-multiple", "value"))
+def update_output(dates):
+    prefix = "You have selected: "
+    if dates:
+        return prefix +  ",   ".join(dates)
+    else:
+        return no_update
+

--- a/docs/datepicker/range.py
+++ b/docs/datepicker/range.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta, date
+
+import dash_mantine_components as dmc
+from dash import Input, Output, html, callback
+from dash.exceptions import PreventUpdate
+
+component = html.Div(
+    [
+        dmc.DatePicker(
+            id="date-range-picker",
+            minDate=date(2020, 8, 5),
+            type="range",
+            value=[datetime.now().date(), datetime.now().date() + timedelta(days=5)],
+        ),
+        dmc.Space(h=10),
+        dmc.Text(id="selected-date-range-picker"),
+    ]
+)
+
+
+@callback(
+    Output("selected-date-range-picker", "children"),
+    Input("date-range-picker", "value"),
+)
+def update_output(dates):
+    prefix = "You have selected from "
+    if dates:
+        return prefix + "   to   ".join(dates)
+    else:
+        raise PreventUpdate

--- a/docs/datepicker/range_single.py
+++ b/docs/datepicker/range_single.py
@@ -1,0 +1,10 @@
+from datetime import datetime, timedelta, date
+
+import dash_mantine_components as dmc
+
+component =dmc.DatePicker(
+    minDate=date(2020, 8, 5),
+    type="range",
+    value=[datetime.now().date(), datetime.now().date() + timedelta(days=5)],
+    allowSingleDateInRange=True,
+)

--- a/docs/datepicker/simple.py
+++ b/docs/datepicker/simple.py
@@ -1,0 +1,24 @@
+from datetime import datetime, date
+
+import dash_mantine_components as dmc
+from dash import Input, Output, html, callback, no_update
+
+component = html.Div(
+    [
+        dmc.DatePicker(
+            id="date-picker",
+            value=datetime.now().date(),
+        ),
+        dmc.Space(h=10),
+        dmc.Text(id="selected-date"),
+    ]
+)
+
+
+@callback(Output("selected-date", "children"), Input("date-picker", "value"))
+def update_output(d):
+    prefix = "You have selected: "
+    if d:
+        return prefix + d
+    else:
+        return no_update

--- a/docs/datepicker/size.py
+++ b/docs/datepicker/size.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+import dash_mantine_components as dmc
+
+from components.configurator import Configurator
+
+target =  dmc.DatePicker(
+    value=datetime.now().date(),
+    size="sm"
+)
+
+configurator = Configurator(target)
+
+configurator.add_slider("size", "sm")
+
+component = configurator.panel

--- a/docs/datepicker/weekend_days.py
+++ b/docs/datepicker/weekend_days.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.DatePicker(
+    value=datetime.now().date(),
+    weekendDays=[5,6,0],
+    firstDayOfWeek=0
+)

--- a/docs/datepicker/year_month_controls.py
+++ b/docs/datepicker/year_month_controls.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.DatePicker(
+    value=datetime.now().date(),
+    monthsListFormat="MM",
+    yearsListFormat="YY"
+)

--- a/docs/datepickerinput/clearable.py
+++ b/docs/datepickerinput/clearable.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.Stack(
+    [
+        dmc.DatePickerInput(
+            value=datetime.now().date(),
+            label="Date not clearable",
+            style={"width": 200},
+        ),
+        dmc.DatePickerInput(
+            value=datetime.now().date(),
+            label="Date clearable",
+            style={"width": 200},
+            clearable=True,
+        )
+    ]
+)

--- a/docs/datepickerinput/datepickerinput.md
+++ b/docs/datepickerinput/datepickerinput.md
@@ -1,0 +1,109 @@
+---
+name: DatePickerInput
+description: Date, multiple dates and dates range picker input. Helps you easily switch between different months, years along with locale support.
+endpoint: /components/datapickerinput
+package: dash_mantine_components
+---
+
+.. toc::
+
+
+### DatePicker props
+DatePickerInput supports all props from DatePicker, read through its documentation to learn about all component features that are not listed on this page.
+
+
+
+### Simple Example
+
+This is a simple example of DatePickerInput tied to a callback. You can either use strings in a valid datetime format such
+as `YYYY-MM-DD` or use the date object from datetime library.
+
+.. exec::docs.datepickerinput.simple
+
+### Multiple dates
+Set type="multiple" to allow user to pick multiple dates.  Note that `value` is a list.
+
+.. exec::docs.datepickerinput.multiple
+
+### Dates range
+Set type="range" to allow user to pick dates range. Note that `value` is a list.
+
+.. exec::docs.datepickerinput.range
+
+
+### Open picker in modal
+By default, DatePicker is rendered inside Popover. You can change that to Modal by setting dropdownType="modal"
+
+
+.. exec::docs.datepickerinput.modal
+
+### Value formats
+
+Use `format` property to change the format of the date displayed in the date picker. You can use any permutation from
+the below table to achieve the desired date format. Note: This is not the format of the value you'll receive from the
+date picker in a callback. That will always follow: `YYYY-MM-DD`.
+
+| Format | Output           | Description                           |
+|--------|------------------|---------------------------------------|
+| YY     | 18               | Two-digit year                        |
+| YYYY   | 2018             | Four-digit year                       |
+| M      | 1-12             | The month: beginning at 1             |
+| MM     | 01-12            | The month: 2-digits                   |
+| MMM    | Jan-Dec          | The abbreviated month name            |
+| MMMM   | January-December | The full month name                   |
+| D      | 1-31             | The day of the month                  |
+| DD     | 01-31            | The day of the month: 2-digits        |
+| d      | 0-6              | The day of the week: with Sunday as 0 |
+| dd     | Su-Sa            | The min name of the day of the week   |
+| ddd    | Sun-Sat          | The short name of the day of the week |
+| dddd   | Sunday-Saturday  | The name of the day of the week       |
+
+### Value Format Examples
+
+.. exec::docs.datepickerinput.formats
+
+
+### Clearable
+
+Set clearable=True prop to display clear button in the right section. Note that if you set rightSection prop, clear button will not be displayed.
+
+.. exec::docs.datepickerinput.clearable
+
+### Error Display
+
+You can convey errors in your date picker by setting the `error` prop. For instance, in the below example we try to
+convey the user that it's a required field and the date can't be an odd date. Since it's a required field, we also
+set `clearable=False`.
+
+.. exec::docs.datepickerinput.errors
+
+### Localization
+
+DatePickerInput component uses dayjs behind the scenes. So you can easily customize locale by including required locale data
+and setting the `locale` prop. Make sure to include proper localization file from dayjs library.
+
+Wrap the DatePickerInput with the DatesProvider.  See the DatesProvider component for more details.
+
+```python
+from dash import Dash
+
+scripts = [
+    "https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.8/dayjs.min.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.8/locale/fr.min.js",
+]
+
+app = Dash(__name__, external_scripts=scripts)
+```
+
+.. exec::docs.datepickerinput.locale
+
+
+### Keyword Arguments
+
+#### DatePicker
+
+.. kwargs::DatePicker
+
+#### DatePickerInput
+
+.. kwargs::DatePickerInput

--- a/docs/datepickerinput/errors.py
+++ b/docs/datepickerinput/errors.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+from dash import Output, Input, callback
+
+component = dmc.DatePickerInput(
+    id="datepicker-error",
+    value=datetime.now().date(),
+    label="Date",
+    required=True,
+    clearable=False,
+    style={"width": 200},
+)
+
+
+@callback(Output("datepicker-error", "error"), Input("datepicker-error", "value"))
+def datepicker_error(date):
+    day = datetime.strptime(date, "%Y-%M-%d").day
+    return "Please select an even date." if day % 2 else ""

--- a/docs/datepickerinput/formats.py
+++ b/docs/datepickerinput/formats.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    spacing="xl",
+    children=[
+        dmc.DatePickerInput(
+            value=datetime.now().date(),
+            valueFormat="ddd, MMM D YY",
+            label="ddd, MMM D YY",
+        ),
+        dmc.DatePickerInput(
+            value=datetime.now().date(),
+            valueFormat="MMMM DD, YY",
+            label="MMMM DD, YY",
+        ),
+        dmc.DatePickerInput(
+            value=datetime.now().date(),
+            valueFormat="DD-MM-YYYY",
+            label="DD-MM-YYYY",
+        ),
+    ],
+)

--- a/docs/datepickerinput/locale.py
+++ b/docs/datepickerinput/locale.py
@@ -1,0 +1,12 @@
+import dash_mantine_components as dmc
+
+component = dmc.DatesProvider(
+    dmc.DatePickerInput(
+        id="fr-date-picker-input",
+        style={"width": 200},
+        label="Sélectionner une date"
+    ),
+    settings={"locale": "fr"}
+)
+
+

--- a/docs/datepickerinput/modal.py
+++ b/docs/datepickerinput/modal.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.DatePickerInput(
+    value=datetime.now().date(),
+    dropdownType="modal",
+    style={"width": 200},
+)

--- a/docs/datepickerinput/multiple.py
+++ b/docs/datepickerinput/multiple.py
@@ -1,0 +1,34 @@
+from datetime import datetime, date, timedelta
+
+import dash_mantine_components as dmc
+from dash import Input, Output, html, callback, no_update
+
+
+component = html.Div(
+    [
+        dmc.DatePickerInput(
+            id="date-picker-input-multiple",
+            label="Pick dates",
+            description="Pick one or more dates",
+            minDate=date(2020, 8, 5),
+            value=[datetime.now().date(), datetime.now().date() + timedelta(days=5)],
+            style={"width": 200},
+            type="multiple",
+            placeholder = "Pick dates",
+            maw = 400,
+            clearable=True
+        ),
+        dmc.Space(h=10),
+        dmc.Text(id="selected-date-input-multiple"),
+    ]
+)
+
+
+@callback(Output("selected-date-input-multiple", "children"), Input("date-picker-input-multiple", "value"))
+def update_output(dates):
+    prefix = "You have selected: "
+    if dates:
+        return prefix +  ",   ".join(dates)
+    else:
+        return no_update
+

--- a/docs/datepickerinput/range.py
+++ b/docs/datepickerinput/range.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timedelta, date
+
+import dash_mantine_components as dmc
+from dash import Input, Output, html, callback
+from dash.exceptions import PreventUpdate
+
+component = html.Div(
+    [
+        dmc.DatePickerInput(
+            id="date-input-range-picker",
+            label="Date Range",
+            description="Select a date range",
+            minDate=date(2020, 8, 5),
+            type="range",
+            value=[datetime.now().date(), datetime.now().date() + timedelta(days=5)],
+            maw=400
+        ),
+        dmc.Space(h=10),
+        dmc.Text(id="selected-date-input-range-picker"),
+    ]
+)
+
+
+@callback(
+    Output("selected-date-input-range-picker", "children"),
+    Input("date-input-range-picker", "value"),
+)
+def update_output(dates):
+    prefix = "You have selected from "
+    if dates:
+        return prefix + "   to   ".join(dates)
+    else:
+        raise PreventUpdate

--- a/docs/datepickerinput/simple.py
+++ b/docs/datepickerinput/simple.py
@@ -1,0 +1,29 @@
+from datetime import datetime, date
+
+import dash_mantine_components as dmc
+from dash import Input, Output, html, callback
+from dash.exceptions import PreventUpdate
+
+component = html.Div(
+    [
+        dmc.DatePickerInput(
+            id="date-picker-input",
+            label="Start Date",
+            description="You can also provide a description",
+            minDate=date(2020, 8, 5),
+            value=datetime.now().date(),  # or string in the format "YYYY-MM-DD"
+            style={"width": 200},
+        ),
+        dmc.Space(h=10),
+        dmc.Text(id="selected-date-input"),
+    ]
+)
+
+
+@callback(Output("selected-date-input", "children"), Input("date-picker-input", "value"))
+def update_output(d):
+    prefix = "You have selected: "
+    if d:
+        return prefix + d
+    else:
+        raise PreventUpdate

--- a/docs/datesprovider/datesprovider.md
+++ b/docs/datesprovider/datesprovider.md
@@ -1,0 +1,25 @@
+---
+name: DatesProvider
+description: DatesProvider component lets you set various settings that are shared across all date components.
+endpoint: /components/datesprovider
+package: dash_mantine_components
+---
+
+.. toc::
+
+### Usage
+
+The DatesProvider component lets you set various settings that are shared across all date components. DatesProvider supports the following settings:
+
+- `locale` – dayjs locale, note that you also need to import corresponding locale module from dayjs. Default value is en.
+- `firstDayOfWeek` – number from 0 to 6, where 0 is Sunday and 6 is Saturday. Default value is 1 – Monday.
+- `weekendDays` – an array of numbers from 0 to 6, where 0 is Sunday and 6 is Saturday. Default value is [0, 6] – Saturday and Sunday.
+
+
+.. exec::docs.datesprovider.simple
+
+### Keyword Arguments
+
+#### DatesProvider
+
+.. kwargs::DatesProvider

--- a/docs/datesprovider/simple.py
+++ b/docs/datesprovider/simple.py
@@ -1,0 +1,19 @@
+import dash_mantine_components as dmc
+
+component = dmc.DatesProvider(
+    children=[
+        dmc.DatePickerInput(
+            id="fr-date-picker-input",
+            style={"width": 200},
+            label="Sélectionner une date"
+        ),
+        dmc.DatePickerInput(
+            id="fr-date-picker-input-2",
+            style={"width": 200},
+            label="Sélectionner une autre date"
+        ),
+    ],
+    settings={"locale": "fr", "firstDayOfWeek": 0, "weekendDays": [0]}
+)
+
+

--- a/run.py
+++ b/run.py
@@ -6,6 +6,7 @@ from components.appshell import create_appshell
 scripts = [
     "https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.8/dayjs.min.js",
     "https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.8/locale/ru.min.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.10.8/locale/fr.min.js",
     "https://www.googletagmanager.com/gtag/js?id=G-4PJELX1C4W",
     "https://media.ethicalads.io/media/client/ethicalads.min.js",
     "https://unpkg.com/hotkeys-js/dist/hotkeys.min.js",


### PR DESCRIPTION
### Added docs for  `DatePicker`, `DatePickerInput` and `DatesProvider`

I created a separate PR because I think  these components may take longer to review and I didn't want to hold up #36 

Breaking changes (not a complete list):
 - DatePickerRange component removed, use DatePickerInput with `type="range"
 - DatePicker component is just the calendar now.  Use DatPickerInput when migrating from previous versions.
 -  use `datesProvider` to set locale
- `inputFormat` prop renamed to `valueFormat`
- `amountOfMonths` prop was renamed to `numberOfColumns` in all components
- `clearable=False` is now the default in `DatePickerInput`



Bugs:
- Need a  better error message if using `type="multiple"`  and the value is not a list.  Currently the error  message is  "t.map is not a function"
- `locale` prop only works in the `DatesProvider` and not in `DatePicker` or `DatePickerInput`

- Missing props
  - `defaultDate` - Sets calendar to a date other than current date.  See the example `docs.datepicker.min_max`
  
  - `defaultLevel`.  There is level prop but no `defaultLevel` prop.  Level doesn't work as in the docs: https://v6.mantine.dev/dates/date-picker/#default-level.  See the example `docs.datepicker.default_level`

