### PR TITLE
More Mantine V6 updates

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -35,6 +35,40 @@ input:invalid {
     }
 }
 
+.demo-container {
+    display: flex;
+    max-width: 100%;
+    overflow: hidden;
+}
+
+.demo-preview {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 20px;
+    justify-content: center;
+}
+
+.demo-controls {
+    width: 250px;
+    padding: 20px;
+    gap: 10px;
+}
+
+.demo-control {
+    margin: 10px;
+}
+
+@media only screen and (max-width: 750px) {
+    .demo-container {
+        flex-direction: column;
+    }
+
+    .demo-controls {
+        width: 100%;
+    }
+}
+
 .dmc-bar {
     background-image: linear-gradient(to right, yellow, orange);
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -34,3 +34,14 @@ input:invalid {
         margin-left: 0;
     }
 }
+
+.dmc-bar {
+    background-image: linear-gradient(to right, yellow, orange);
+}
+
+.dmc-thumb {
+    border-color: orange;
+    height: 20px;
+    width: 20px;
+    background-color: white;
+}

--- a/components/appshell.py
+++ b/components/appshell.py
@@ -10,6 +10,7 @@ from dash import (
 )
 
 from components.header import create_header
+from components.sidebar import create_navbar_drawer, create_side_navbar
 from lib.constants import PRIMARY_COLOR
 
 
@@ -39,6 +40,8 @@ def create_appshell(data):
                 dcc.Location(id="url", refresh="callback-nav"),
                 dmc.Notifications(),
                 create_header(data),
+                create_side_navbar(data),
+                create_navbar_drawer(data),
                 html.Div(
                     dmc.Container(size="lg", pt=90, children=page_container),
                     id="wrapper",

--- a/components/header.py
+++ b/components/header.py
@@ -148,7 +148,7 @@ clientside_callback(
         }
     }
     """,
-    Output("url", "pathname"),
+    Output("url", "href"),
     Input("select-component", "value"),
 )
 

--- a/components/header.py
+++ b/components/header.py
@@ -129,6 +129,19 @@ def create_header(data):
                                         id="color-scheme-toggle",
                                         size="lg",
                                     ),
+                                    dmc.MediaQuery(
+                                        dmc.ActionIcon(
+                                            DashIconify(
+                                                icon="radix-icons:hamburger-menu",
+                                                width=18,
+                                            ),
+                                            id="drawer-hamburger-button",
+                                            variant="outline",
+                                            size=36,
+                                        ),
+                                        largerThan="lg",
+                                        styles={"display": "none"},
+                                    ),
                                 ],
                             ),
                         ),

--- a/components/sidebar.py
+++ b/components/sidebar.py
@@ -1,3 +1,4 @@
+from dash import clientside_callback, Input, Output
 import dash_mantine_components as dmc
 from dash_iconify import DashIconify
 
@@ -95,3 +96,9 @@ def create_navbar_drawer(nav_data):
         ],
     )
 
+clientside_callback(
+    """function(n_clicks) { return true }""",
+    Output("components-navbar-drawer", "opened"),
+    Input("drawer-hamburger-button", "n_clicks"),
+    prevent_initial_call=True,
+)

--- a/components/sidebar.py
+++ b/components/sidebar.py
@@ -1,0 +1,91 @@
+import dash_mantine_components as dmc
+from dash_iconify import DashIconify
+
+excluded_links = ["/404", "/getting-started", "/styles-api" , "/style-props", "/dash-iconify"]
+
+
+def create_main_nav_link(icon, label, href):
+    return dmc.Anchor(
+        dmc.Group(
+            [
+                DashIconify(
+                    icon=icon, width=23, color=dmc.theme.DEFAULT_COLORS["indigo"][5]
+                ),
+                dmc.Text(label, size="sm"),
+            ]
+        ),
+        href=href,
+        variant="text",
+        mb=5,
+    )
+
+
+def create_side_nav_content(nav_data):
+    main_links = dmc.Stack(
+        spacing="sm",
+        mt=20,
+        children=[
+            create_main_nav_link(
+                icon="material-symbols:rocket-launch-rounded",
+                label="Getting Started",
+                href="/getting-started",
+            ),
+            create_main_nav_link(
+                icon="material-symbols:style",
+                label="Styles API",
+                href="/styles-api",
+            ),
+            create_main_nav_link(
+                icon="material-symbols:measuring-tape-rounded",
+                label="Style Props",
+                href="/style-props",
+            ),
+            create_main_nav_link(
+                icon="material-symbols:cookie-rounded",
+                label="Dash Iconify",
+                href="/dash-iconify",
+            ),
+        ],
+    )
+
+    links = [
+        dmc.NavLink(label=entry["name"], href=entry["path"], styles={"root": {"height": 32}})
+        for entry in nav_data if entry["path"] not in excluded_links
+    ]
+
+    return dmc.Stack(spacing=0, children=[main_links, *links, dmc.Space(h=20)], px=25)
+
+
+def create_side_navbar(nav_data):
+    return dmc.Navbar(
+        fixed=True,
+        id="components-navbar",
+        position={"top": 70},
+        width={"base": 300},
+        children=[
+            dmc.ScrollArea(
+                offsetScrollbars=True,
+                type="scroll",
+                children=create_side_nav_content(nav_data),
+            )
+        ],
+    )
+
+
+def create_navbar_drawer(nav_data):
+    return dmc.Drawer(
+        id="components-navbar-drawer",
+        overlayProps={"opacity": 0.55, "blur": 3},
+        zIndex=9,
+        size=300,
+        children=[
+            dmc.ScrollArea(
+                offsetScrollbars=True,
+                type="scroll",
+                style={"height": "100vh"},
+                pt=20,
+                children=create_side_nav_content(nav_data),
+            )
+        ],
+    )
+

--- a/components/sidebar.py
+++ b/components/sidebar.py
@@ -1,7 +1,13 @@
 import dash_mantine_components as dmc
 from dash_iconify import DashIconify
 
-excluded_links = ["/404", "/getting-started", "/styles-api" , "/style-props", "/dash-iconify"]
+excluded_links = [
+    "/404",
+    "/components/getting-started",
+    "/components/styles-api" ,
+    "/components/style-props",
+    "/components/dash-iconify"
+]
 
 
 def create_main_nav_link(icon, label, href):

--- a/components/sidebar.py
+++ b/components/sidebar.py
@@ -3,10 +3,10 @@ from dash_iconify import DashIconify
 
 excluded_links = [
     "/404",
-    "/components/getting-started",
-    "/components/styles-api" ,
-    "/components/style-props",
-    "/components/dash-iconify"
+    "/getting-started",
+    "/styles-api" ,
+    "/style-props",
+    "/dash-iconify"
 ]
 
 

--- a/docs/aspectratio/aspectratio.md
+++ b/docs/aspectratio/aspectratio.md
@@ -1,0 +1,29 @@
+---
+name: AspectRatio
+description: Use the Aspect component to maintain responsive consistent width/height ratio.
+endpoint: /components/aspectratio
+package: dash_mantine_components
+---
+
+.. toc::
+
+### Image 
+
+.. exec::docs.aspectratio.simple
+
+
+### Map embed
+
+.. exec::docs.aspectratio.map
+
+
+### Video embed
+
+.. exec::docs.aspectratio.video
+
+
+### Keyword Arguments
+
+#### AspectRatio
+
+.. kwargs::AspectRatio

--- a/docs/aspectratio/map.py
+++ b/docs/aspectratio/map.py
@@ -1,0 +1,10 @@
+import dash_mantine_components as dmc
+from dash import html
+
+component = dmc.AspectRatio(
+    html.Iframe(
+        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3025.3063874233135!2d-74.04668908358428!3d40.68924937933441!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c25090129c363d%3A0x40c6a5770d25022b!2sStatue%20of%20Liberty%20National%20Monument!5e0!3m2!1sen!2sru!4v1644262070010!5m2!1sen!2sru",
+        title = "Google map",
+    ),
+    ratio=16 / 9
+)

--- a/docs/aspectratio/simple.py
+++ b/docs/aspectratio/simple.py
@@ -1,0 +1,9 @@
+import dash_mantine_components as dmc
+
+component = dmc.AspectRatio(
+    dmc.Image(
+        src="https://www.nasa.gov/wp-content/uploads/2022/07/web_first_images_release.png",
+        alt="Carina Nebula"
+    ),
+    ratio=720 / 1080, maw=400, mx="auto"
+)

--- a/docs/aspectratio/video.py
+++ b/docs/aspectratio/video.py
@@ -1,0 +1,11 @@
+import dash_mantine_components as dmc
+from dash import html
+
+component = dmc.AspectRatio(
+    html.Iframe(
+       src="https://www.youtube.com/embed/KsTKREWoVC4",
+        title = "YouTube video player",
+        allow = "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen",
+    ),
+    ratio=16 / 9
+)

--- a/docs/colorinput/colorinput.md
+++ b/docs/colorinput/colorinput.md
@@ -1,0 +1,97 @@
+---
+name: ColorInput
+description: Capture color  inputs from user.
+endpoint: /components/colorinput
+package: dash_mantine_components
+---
+
+.. toc::
+
+### Simple Example
+
+.. exec::docs.colorinput.simple
+
+### Formats
+Component supports hex, hexa, rgb, rgba, hsl and hsla color formats. Slider to change opacity is displayed only for hexa, rgba and hsla formats.
+
+.. exec::docs.colorinput.formats
+   :code: false
+
+### Disable free input
+To disable free input set disallowInput prop.
+
+.. exec::docs.colorinput.disable-free-input
+
+### With swatches
+With swatches
+You can add any amount of predefined color swatches.  By default, there will be 10 swatches per row, you can change this with `swatchesPerRow` prop, like in ColorPicker component.
+
+.. exec::docs.colorinput.swatches
+
+If you need to restrict color picking to certain colors – disable color picker and disallow free input:
+
+.. exec::docs.colorinput.swatches-only
+
+### Remove or replace preview
+By default, color preview will be rendered on the left side of the input, you can remove it (withPreview=False prop) or replace with an icon.
+
+.. exec::docs.colorinput.preview
+
+### Eye dropper
+Set `withEyeDropper` prop to display eye dropper icon in the right section. This feature depends on `EyeDropper` API, the eye dropper will not be rendered if the API is not supported.
+
+.. exec::docs.colorinput.eyedropper
+
+### Input props
+
+.. exec::docs.colorinput.interactive
+   :code:  false
+
+### Accessibility
+#### Color picker focus
+Color picker is not focusable, users without mouse access can select color only by entering it into input manually. If you want to make component accessible do not disable free input.
+
+#### aria-label
+Provide `aria-labe`l in case you use component without label for screen reader support:
+
+```python
+import dash_mantine_components
+
+dmc.ColorInput(value="#ffffff")  # not ok, input is not labeled
+dmc.ColorInput(label="Pick color") # ok, input and label is connected
+dmc.ColorInput(**{"aria-label": "My input"}) # ok, label is not visible but will be announced by screen readers
+
+```
+
+### StylesAPI
+
+| Name          | Static selector                   | Description                                                               |
+|:--------------|:----------------------------------|:--------------------------------------------------------------------------|
+| wrapper       | .mantine-ColorInput-wrapper       | Root element                                                              |
+| icon          | .mantine-ColorInput-icon          | Input icon wrapper on the left side of the input, controlled by icon prop |
+| input         | .mantine-ColorInput-input         | Main input element                                                        |
+| rightSection  | .mantine-ColorInput-rightSection  | Input right section, controlled by rightSection prop                      |
+| root          | .mantine-ColorInput-root          | Root element                                                              |
+| label         | .mantine-ColorInput-label         | Label element styles, defined by label prop                               |
+| error         | .mantine-ColorInput-error         | Error element styles, defined by error prop                               |
+| description   | .mantine-ColorInput-description   | Description element styles, defined by description prop                   |
+| required      | .mantine-ColorInput-required      | Required asterisk element styles, defined by required prop                |
+| body          | .mantine-ColorInput-body          | Includes hue and alpha sliders and color preview                          |
+| preview       | .mantine-ColorInput-preview       | Color preview                                                             |
+| sliders       | .mantine-ColorInput-sliders       | Hue and alpha sliders wrapper                                             |
+| slider        | .mantine-ColorInput-slider        | Alpha and hue sliders                                                     |
+| sliderOverlay | .mantine-ColorInput-sliderOverlay | Hue and alpha sliders overlays                                            |
+| thumb         | .mantine-ColorInput-thumb         | Hue, alpha and saturation sliders thumbs                                  |
+| saturation    | .mantine-ColorInput-saturation    | Saturation slider                                                         |
+| swatch        | .mantine-ColorInput-swatch        | ColorSwatch component in swatches list                                    |
+| swatches      | .mantine-ColorInput-swatches      | Wrapper around all swatches                                               |
+| dropdown      | .mantine-ColorInput-dropdown      | Dropdown root element                                                     |
+| arrow         | .mantine-ColorInput-arrow         | Dropdown arrow                                                            |
+
+
+
+### Keyword Arguments
+
+#### ColorPicker
+
+.. kwargs::ColorInput

--- a/docs/colorinput/disable-free-input.py
+++ b/docs/colorinput/disable-free-input.py
@@ -1,0 +1,5 @@
+import dash_mantine_components as dmc
+
+
+component = dmc.ColorInput(disallowInput=True, label="Your favorite color", value="#e05e5e")
+

--- a/docs/colorinput/eyedropper.py
+++ b/docs/colorinput/eyedropper.py
@@ -1,0 +1,5 @@
+import dash_mantine_components as dmc
+
+
+component = dmc.ColorInput(withEyeDropper=True, label="Pick any color from the page")
+

--- a/docs/colorinput/formats.py
+++ b/docs/colorinput/formats.py
@@ -1,0 +1,11 @@
+import dash_mantine_components as dmc
+
+from components.configurator import Configurator
+
+target = dmc.ColorInput(value="#C5D899", format="rgb", label="Select color")
+
+configurator = Configurator(target)
+
+configurator.add_select("format",["hex", "hexa", "rgba", "rgb", "hsl", "hsla"], "rgb")
+
+component = configurator.panel

--- a/docs/colorinput/interactive.py
+++ b/docs/colorinput/interactive.py
@@ -1,0 +1,21 @@
+import dash_mantine_components as dmc
+
+from components.configurator import Configurator
+
+target = dmc.ColorInput(
+    label="Your favorite color", placeholder="Pick color", style={"width": 300}
+)
+
+configurator = Configurator(target)
+configurator.add_text_input("placeholder", "Pick color", **{"placeholder":"Placeholder"})
+configurator.add_text_input("label",  "Your favorite color", **{"placeholder":"Label"})
+configurator.add_text_input("description","", **{"placeholder":"Description"})
+configurator.add_text_input("error","", **{"placeholder":"Error"})
+configurator.add_select("variant", ["default", "filled", "unstyled"], "defaut")
+configurator.add_slider("size", "sm")
+configurator.add_slider("radius", "sm")
+configurator.add_switch("withAsterisk", True)
+configurator.add_switch("disabled", False)
+configurator.add_switch("withEyeDropper", False)
+
+component = configurator.panel

--- a/docs/colorinput/preview.py
+++ b/docs/colorinput/preview.py
@@ -1,0 +1,19 @@
+import dash_mantine_components as dmc
+from dash_iconify import DashIconify
+
+component = dmc.Stack(
+    [
+        dmc.ColorInput(
+            label="Without preview",
+            withPreview=False,
+            value="#40c057",
+        ),
+        dmc.ColorInput(
+            label="With icon",
+            icon=DashIconify(icon="cil:paint"),
+            withPreview=False,
+            value="#40c057",
+        ),
+    ]
+)
+

--- a/docs/colorinput/simple.py
+++ b/docs/colorinput/simple.py
@@ -1,0 +1,15 @@
+import dash_mantine_components as dmc
+from dash import Output, Input, html, callback
+
+component = html.Div(
+    [
+        dmc.ColorInput(id="color-input", label="Your favorite color"),
+        dmc.Space(h=10),
+        dmc.Text(id="selected-color-input"),
+    ]
+)
+
+
+@callback(Output("selected-color-input", "children"), Input("color-input", "value"))
+def pick(color):
+    return f"You selected: {color}"

--- a/docs/colorinput/swatches-only.py
+++ b/docs/colorinput/swatches-only.py
@@ -1,0 +1,10 @@
+import dash_mantine_components as dmc
+
+component = dmc.ColorInput(
+    label="Your favorite color",
+    value="#40c057",
+    disallowInput=True,
+    withPicker=False,
+    swatches = dmc.theme.DEFAULT_COLORS["red"] + dmc.theme.DEFAULT_COLORS["green"]
+)
+

--- a/docs/colorinput/swatches.py
+++ b/docs/colorinput/swatches.py
@@ -1,0 +1,12 @@
+import dash_mantine_components as dmc
+
+component = dmc.ColorInput(
+    label="Your favorite color",
+    value="#e05e5e",
+    format="hex",
+    swatches = [
+        '#25262b', '#868e96', '#fa5252', '#e64980', '#be4bdb', '#7950f2', '#4c6ef5',
+        '#228be6', '#15aabf', '#12b886', '#40c057', '#82c91e', '#fab005', '#fd7e14'
+    ]
+)
+

--- a/docs/dash-iconify/dash-iconify.md
+++ b/docs/dash-iconify/dash-iconify.md
@@ -1,7 +1,7 @@
 ---
 name: Dash Iconify
 description: Add icons to your dash apps the simplest and the most efficient way.
-endpoint: /components/dash-iconify
+endpoint: /dash-iconify
 package: dash_mantine_components
 ---
 

--- a/docs/dateinput/clearable.py
+++ b/docs/dateinput/clearable.py
@@ -1,0 +1,3 @@
+import dash_mantine_components as dmc
+
+component = dmc.DateInput(clearable=True, label="Date input", placeholder="Date Input")

--- a/docs/dateinput/dateinput.md
+++ b/docs/dateinput/dateinput.md
@@ -1,0 +1,78 @@
+---
+name: DateInput
+description: Free date input
+endpoint: /components/dateinput
+package: dash_mantine_components
+---
+
+.. toc::
+
+
+### DateInput props
+DateInput supports all props from DatePicker, read through its documentation to learn about all component features that are not listed on this page.
+
+
+
+### Simple Example
+
+This is a simple example of DateInput tied to a callback. You can type a date or select from the DatePicker
+
+.. exec::docs.dateinput.simple
+
+### Value formats
+
+Use `format` property to change the format of the date displayed in the date input field. You can use any permutation from
+the below table to achieve the desired date format. Note: This is not the format of the value you'll receive from the
+date picker in a callback. That will always follow: `YYYY-MM-DD`.
+
+| Format | Output           | Description                           |
+|--------|------------------|---------------------------------------|
+| YY     | 18               | Two-digit year                        |
+| YYYY   | 2018             | Four-digit year                       |
+| M      | 1-12             | The month: beginning at 1             |
+| MM     | 01-12            | The month: 2-digits                   |
+| MMM    | Jan-Dec          | The abbreviated month name            |
+| MMMM   | January-December | The full month name                   |
+| D      | 1-31             | The day of the month                  |
+| DD     | 01-31            | The day of the month: 2-digits        |
+| d      | 0-6              | The day of the week: with Sunday as 0 |
+| dd     | Su-Sa            | The min name of the day of the week   |
+| ddd    | Sun-Sat          | The short name of the day of the week |
+| dddd   | Sunday-Saturday  | The name of the day of the week       |
+
+### Value Format 
+
+.. exec::docs.dateinput.formats
+
+### With Time
+
+Include time in `valueFormat` to allow hours, minutes and seconds to be entered.
+
+.. exec::docs.dateinput.time
+
+### Clearable
+
+Set clearable prop to allow removing value from the input. Input will be cleared if user selects the same date in dropdown or clears input value.
+
+When `clearable=True`, a clear button in the right section is displayed. Note that if you set rightSection prop, clear button will not be displayed.
+
+.. exec::docs.dateinput.clearable
+
+### Min and max date
+Set `minDate` and `maxDate` props to define min and max dates. If date that is after `maxDate` or before `minDate` is entered, then it will be considered invalid and input value will be reverted to last known valid date value.
+
+.. exec::docs.dateinput.minmax
+
+### Input props
+
+.. exec::docs.dateinput.interactive
+   :code: false
+
+
+
+
+### Keyword Arguments
+
+#### DateInput
+
+.. kwargs::DateInput

--- a/docs/dateinput/formats.py
+++ b/docs/dateinput/formats.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    spacing="xl",
+    children=[
+        dmc.DateInput(
+            value=datetime.now().date(),
+            valueFormat="ddd, MMM D YY",
+            label="ddd, MMM D YY",
+        ),
+        dmc.DateInput(
+            value=datetime.now().date(),
+            valueFormat="MMMM DD, YY",
+            label="MMMM DD, YY",
+        ),
+        dmc.DateInput(
+            value=datetime.now().date(),
+            valueFormat="DD-MM-YYYY",
+            label="DD-MM-YYYY",
+        ),
+    ],
+)

--- a/docs/dateinput/interactive.py
+++ b/docs/dateinput/interactive.py
@@ -1,0 +1,22 @@
+import dash_mantine_components as dmc
+
+from components.configurator import Configurator
+
+target = dmc.DateInput(
+    label="Enter date", placeholder="Enter date", style={"width": 350}
+)
+
+configurator = Configurator(target)
+configurator.add_text_input("placeholder", "Enter date", **{"placeholder":"Placeholder"})
+configurator.add_text_input("label",  "Enter date", **{"placeholder":"Label"})
+configurator.add_text_input("description","", **{"placeholder":"Description"})
+configurator.add_text_input("error","", **{"placeholder":"Error"})
+configurator.add_select("variant", ["default", "filled", "unstyled"], "defaut")
+configurator.add_slider("size", "sm")
+configurator.add_slider("radius", "sm")
+configurator.add_switch("withAsterisk", True)
+configurator.add_switch("disabled", False)
+configurator.add_switch("clearable", True)
+
+
+component = configurator.panel

--- a/docs/dateinput/minmax.py
+++ b/docs/dateinput/minmax.py
@@ -1,0 +1,8 @@
+import dash_mantine_components as dmc
+
+component = dmc.DateInput(
+    minDate="2023-10-05",
+    maxDate="2023-10-15",
+    placeholder="Date input",
+    label="Select valid date"
+)

--- a/docs/dateinput/simple.py
+++ b/docs/dateinput/simple.py
@@ -1,0 +1,24 @@
+import dash_mantine_components as dmc
+from dash import Input, Output, html, callback
+
+component = html.Div(
+    [
+        dmc.DateInput(
+            id="dateinput2",
+            label="Enter a date",
+            description="You can type a date or select from the calendar",
+            style={"width": 350},
+        ),
+        dmc.Space(h=10),
+        dmc.Text(id="selected-dateinput2"),
+    ]
+)
+
+
+@callback(Output("selected-dateinput2", "children"), Input("dateinput2", "value"))
+def update_output(d):
+    prefix = "You entered: "
+    if d:
+        return prefix + d
+    else:
+        return ""

--- a/docs/dateinput/time.py
+++ b/docs/dateinput/time.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+import dash_mantine_components as dmc
+
+
+component = dmc.DateInput(
+    valueFormat="DD/MM/YYYY HH:mm:ss",
+    label="Date and Time input",
+    value=datetime.now()
+)

--- a/docs/datepickerinput/datepickerinput.md
+++ b/docs/datepickerinput/datepickerinput.md
@@ -1,7 +1,7 @@
 ---
 name: DatePickerInput
 description: Date, multiple dates and dates range picker input. Helps you easily switch between different months, years along with locale support.
-endpoint: /components/datapickerinput
+endpoint: /components/datepickerinput
 package: dash_mantine_components
 ---
 

--- a/docs/flex/flex.md
+++ b/docs/flex/flex.md
@@ -1,0 +1,26 @@
+---
+name: Flex
+description: Use the Flex component to compose elements in a flex container.
+endpoint: /components/flex
+package: dash_mantine_components
+---
+
+.. toc::
+
+### Introduction
+
+.. exec::docs.flex.interactive
+   
+
+
+### Responsive Props
+
+Flex component props can have responsive values the same way as other style props:
+
+.. exec::docs.flex.responsive
+
+### Keyword Arguments
+
+#### Flex
+
+.. kwargs::Flex

--- a/docs/flex/flex.md
+++ b/docs/flex/flex.md
@@ -10,6 +10,7 @@ package: dash_mantine_components
 ### Introduction
 
 .. exec::docs.flex.interactive
+   :code: false
    
 
 

--- a/docs/flex/interactive.py
+++ b/docs/flex/interactive.py
@@ -1,0 +1,27 @@
+import dash_mantine_components as dmc
+
+from components.configurator import Configurator
+
+target = dmc.Flex(
+    [
+        dmc.Button("Button 1"),
+        dmc.Button("Button 2"),
+        dmc.Button("Button 3"),
+    ],
+    mih=50,
+    bg="rgba(0, 0, 0, .3)",
+    gap="md",
+    justify="flex-start",
+    align="flex-start",
+    direction="row",
+    wrap="wrap",
+)
+
+configurator = Configurator(target)
+configurator.add_slider("gap", "md")
+configurator.add_select("justify", ["flex-start", "center", "flex-end"],"center")
+configurator.add_select("align", ["flex-start", "center", "flex-end"], "flex-start")
+configurator.add_select("direction", ["row", "column", "row-reverse", "column-reverse"], "row")
+configurator.add_select("wrap",["wrap", "nowrap", "wrap-reverse"],"wrap")
+
+component = configurator.panel

--- a/docs/flex/responsive.py
+++ b/docs/flex/responsive.py
@@ -1,0 +1,12 @@
+import dash_mantine_components as dmc
+
+component = dmc.Flex(
+    [
+        dmc.Button("Button 1"),
+        dmc.Button("Button 2"),
+        dmc.Button("Button 3"),
+    ],
+    direction={"base": "column", "sm": "row"},
+    gap={"base": "sm", "sm": "lg"},
+    justify={"sm": "center"},
+)

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -48,7 +48,7 @@ code [here](https://github.com/snehilvj/dmc-docs) for some inspiration.
 While going through this documentation, you will come across interactive demos meant to show an overview as well as the overall effect of different combinations of a component's props.
 
 .. exec::docs.getting-started.interactive
-        :code: false
+   :code: false
 
 Note that this documentation has some additional styling applied to it. So when you actually use these components, they 
 might look a bit different. You can check out [MantineProvider](/components/mantineprovider) for more details on

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -1,0 +1,89 @@
+---
+name: Getting Started
+endpoint: /getting-started
+description: Install dash-mantine-components using pip, poetry, or conda.
+dmc: false
+---
+
+.. toc::
+
+##### PyPI
+
+You can install `dash-mantine-components` from PyPI via pip or poetry.
+
+```bash
+pip install dash-mantine-components
+```
+
+```bash
+poetry add dash-mantine-components
+```
+
+##### Simple Usage
+
+Using Dash Mantine Components is pretty much the same as using Dash Bootstrap Components or the official Dash 
+components.
+
+```python
+import dash_mantine_components as dmc
+from dash import Dash
+
+app = Dash(__name__)
+
+app.layout = dmc.Alert(
+    "Hi from Dash Mantine Components. You can create some great looking dashboards using me!",
+    title="Welcome!",
+    color="violet",
+)
+
+if __name__ == "__main__":
+    app.run_server()
+```
+
+##### Documentation
+
+This entire documentation has been created almost entirely using Dash Mantine Components. You can check out the source
+code [here](https://github.com/snehilvj/dmc-docs) for some inspiration.
+
+While going through this documentation, you will come across interactive demos meant to show an overview as well as the overall effect of different combinations of a component's props.
+
+.. exec::docs.getting-started.interactive
+        :code: false
+
+Note that this documentation has some additional styling applied to it. So when you actually use these components, they 
+might look a bit different. You can check out [MantineProvider](/components/mantineprovider) for more details on
+theming and customizations.
+
+Here's how you can add the same styling to your apps:
+
+```python
+import dash_mantine_components as dmc
+from dash import Dash
+
+app = Dash(
+    __name__,
+    external_stylesheets=[
+        # include google fonts
+        "https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;900&display=swap"
+    ],
+)
+
+app.layout = dmc.MantineProvider(
+    theme={
+        "fontFamily": "'Inter', sans-serif",
+        "primaryColor": "indigo",
+        "components": {
+            "Button": {"styles": {"root": {"fontWeight": 400}}},
+            "Alert": {"styles": {"title": {"fontWeight": 500}}},
+            "AvatarGroup": {"styles": {"truncated": {"fontWeight": 500}}},
+        },
+    },
+    inherit=True,
+    withGlobalStyles=True,
+    withNormalizeCSS=True,
+    children=[dmc.Button("Settings")],
+)
+
+if __name__ == "__main__":
+    app.run_server()
+```

--- a/docs/getting-started/interactive.py
+++ b/docs/getting-started/interactive.py
@@ -1,0 +1,19 @@
+import dash_mantine_components as dmc
+
+from components.configurator import Configurator
+
+TARGET_ID = "getting-started-button-interactive"
+
+target = dmc.Center(dmc.Button("Settings", id=TARGET_ID))
+
+configurator = Configurator(target, TARGET_ID)
+
+configurator.add_select(
+    "variant",
+    ["link", "filled", "outline", "light", "gradient", "subtle", "default"],
+    "filled",
+)
+configurator.add_colorpicker("color", "indigo")
+configurator.add_switch("loading", False)
+
+component = configurator.panel

--- a/docs/mark/color.py
+++ b/docs/mark/color.py
@@ -1,0 +1,7 @@
+import dash_mantine_components as dmc
+
+component = dmc.Text([
+    "Highlight ",
+    dmc.Mark("this section", color="cyan"),
+    " of the text."
+])

--- a/docs/mark/mark.md
+++ b/docs/mark/mark.md
@@ -1,0 +1,29 @@
+---
+name: Mark
+description: Use the Mark component to highlight part of the text.
+endpoint: /components/mark
+package: dash_mantine_components
+---
+
+.. toc::
+
+### Introduction
+
+.. exec::docs.mark.simple
+  
+This component is used in other Mantine components, for example, in Highlight:
+
+```python
+dmc.Highlight(
+    "Highlight this, definitely this and also this!", highlight="this"
+)
+```
+### Change color
+
+.. exec::docs.mark.color
+
+### Keyword Arguments
+
+#### Mark
+
+.. kwargs::Mark

--- a/docs/mark/simple.py
+++ b/docs/mark/simple.py
@@ -1,0 +1,7 @@
+import dash_mantine_components as dmc
+
+component = dmc.Text([
+    "Thanks for checking out ",
+    dmc.Mark("Dash Mantine Components."),
+    " You are awesome!"
+])

--- a/docs/numberinput/numberinput.md
+++ b/docs/numberinput/numberinput.md
@@ -11,6 +11,7 @@ package: dash_mantine_components
 
 
 .. exec::docs.numberinput.interactive
+    :code: false
 
 ### Simple Example
 

--- a/docs/pininput/accessibility.py
+++ b/docs/pininput/accessibility.py
@@ -1,0 +1,6 @@
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    dmc.PinInput(oneTimeCode=True, **{"aria-label": "One Time Code"}),
+    position="center"
+)

--- a/docs/pininput/disabled.py
+++ b/docs/pininput/disabled.py
@@ -1,0 +1,6 @@
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    dmc.PinInput(disabled=True),
+    position="center"
+)

--- a/docs/pininput/error.py
+++ b/docs/pininput/error.py
@@ -1,0 +1,6 @@
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    dmc.PinInput(error=True),
+    position="center"
+)

--- a/docs/pininput/length.py
+++ b/docs/pininput/length.py
@@ -1,0 +1,6 @@
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    dmc.PinInput(length=8),
+    position="center"
+)

--- a/docs/pininput/masked.py
+++ b/docs/pininput/masked.py
@@ -1,0 +1,6 @@
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    dmc.PinInput(mask=True),
+    position="center"
+)

--- a/docs/pininput/onetime.py
+++ b/docs/pininput/onetime.py
@@ -1,0 +1,6 @@
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    dmc.PinInput(oneTimeCode=True),
+    position="center"
+)

--- a/docs/pininput/pininput.md
+++ b/docs/pininput/pininput.md
@@ -1,0 +1,75 @@
+---
+name: PinInput
+description: Capture pin code or one time password from the user.
+endpoint: /components/pininput
+package: dash_mantine_components
+---
+
+.. toc::
+
+### Simple Example
+
+.. exec::docs.pininput.simple
+
+
+### Length
+
+Set `length` prop to control number of rendered fields.
+
+.. exec::docs.pininput.length
+
+### Type
+
+By default, PinInput accepts letters and numbers. To allow numbers only, set type="number":
+
+.. exec::docs.pininput.type
+
+### Placeholder
+Set `placeholder` to change placeholder of all fields. Note that it only accepts strings.
+
+.. exec::docs.pininput.placeholder
+
+### Disabled state
+
+.. exec::docs.pininput.disabled
+
+
+### Error state
+
+.. exec::docs.pininput.error
+
+
+### Masked
+
+.. exec::docs.pininput.masked
+
+
+### One Time Code
+Some operating systems expose last received SMS code to be used by applications like your keyboard. If the current form input asks for this code, your keyboard adapts and proposes the code as keyboard-suggestion. Prop oneTimeCode makes your input setting autocomplete="one-time-code" which allows using that feature.
+
+.. exec::docs.pininput.onetime
+
+### Accessibility
+Inputs do not have associated labels, set aria-label to make component visible to screen reader:
+
+.. exec::docs.pininput.accessibility
+
+
+
+
+### Styles API
+
+| Name         | Static selector                | Description                                                               |
+|:-------------|:-------------------------------|:--------------------------------------------------------------------------|
+| root         | .mantine-PinInput-root         | Root element                                                              |
+| wrapper      | .mantine-PinInput-wrapper      | Root Input element                                                        |
+| icon         | .mantine-PinInput-icon         | Input icon wrapper on the left side of the input, controlled by icon prop |
+| input        | .mantine-PinInput-input        | Main input element                                                        |
+| rightSection | .mantine-PinInput-rightSection | Input right section, controlled by rightSection prop                      |
+
+
+### Keyword Arguments
+
+#### PinInput
+
+.. kwargs::PinInput

--- a/docs/pininput/placeholder.py
+++ b/docs/pininput/placeholder.py
@@ -1,0 +1,6 @@
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    dmc.PinInput(placeholder="⊡"),
+    position="center"
+)

--- a/docs/pininput/simple.py
+++ b/docs/pininput/simple.py
@@ -1,0 +1,6 @@
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    dmc.PinInput(),
+    position="center"
+)

--- a/docs/pininput/type.py
+++ b/docs/pininput/type.py
@@ -1,0 +1,6 @@
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    dmc.PinInput(type="number"),
+    position="center"
+)

--- a/docs/popover/focustrap.py
+++ b/docs/popover/focustrap.py
@@ -1,0 +1,22 @@
+import dash_mantine_components as dmc
+
+component = dmc.Popover(
+    [
+        dmc.PopoverTarget(dmc.Button("Toggle Popover")),
+        dmc.PopoverDropdown(
+            [
+                dmc.TextInput(label="Name", placeholder="Name", size="xs"),
+                dmc.TextInput(label="Email", placeholder="john@doe.com",size="xs", mt="xs")
+            ]
+        )
+
+    ],
+    width=300,
+    position="bottom",
+    withArrow=True,
+    trapFocus=True,
+    shadow="md",
+    
+
+
+)

--- a/docs/popover/inline.py
+++ b/docs/popover/inline.py
@@ -1,0 +1,17 @@
+import dash_mantine_components as dmc
+
+component = dmc.Flex(
+    [
+        "Here is some text with ",
+        dmc.Popover(
+            [
+                dmc.PopoverTarget(dmc.Mark(" an inline popover ")),
+                dmc.PopoverDropdown(" more info")
+            ],
+            middlewares={"flip": True, "shift": True, "inline": True}
+        ),
+        " and more text after."
+    ],
+    direction="row",
+    gap="xs"
+)

--- a/docs/popover/popover.md
+++ b/docs/popover/popover.md
@@ -1,0 +1,43 @@
+---
+name: Popover
+description: Display popover section relative to given target element.
+endpoint: /components/popover
+package: dash_mantine_components
+---
+
+.. toc::
+
+### Simple Example
+
+.. exec::docs.popover.simple
+
+### Focus Trap
+If you need to use any interactive elements within Popover, set `trapFocus` prop:
+
+.. exec::docs.popover.focustrap
+
+### Inline elements
+Enable inline middleware to use Popover with inline elements.
+
+.. exec::docs.popover.inline
+
+
+### Same width
+Set width="target" prop to make Popover dropdown take the same width as target element.
+.. exec::docs.popover.same-width
+
+### Keyword Arguments
+
+#### Popover
+
+.. kwargs::Popover
+
+
+### PopoverTarget
+.. kwargs::PopoverTarget
+
+### PopoverDropdown
+
+.. kwargs::PopoverDropdown
+
+

--- a/docs/popover/same-width.py
+++ b/docs/popover/same-width.py
@@ -1,0 +1,11 @@
+import dash_mantine_components as dmc
+
+component = dmc.Popover(
+    [
+        dmc.PopoverTarget(dmc.Button("Toggle Popover", w=200)),
+        dmc.PopoverDropdown(
+            dmc.Text("This popover has same width as target, it is useful when you are building input dropdowns")
+        )
+    ],
+    width="target", position="bottom", withArrow=True, shadow="md",
+)

--- a/docs/popover/simple.py
+++ b/docs/popover/simple.py
@@ -1,0 +1,10 @@
+import dash_mantine_components as dmc
+
+component = dmc.Popover(
+    [
+        dmc.PopoverTarget(dmc.Button("Toggle Popover")),
+        dmc.PopoverDropdown(dmc.Text("This popover is opened on button click"))
+
+    ],
+    width=200, position="bottom", withArrow=True, shadow="md",
+)

--- a/docs/rating/fractions.py
+++ b/docs/rating/fractions.py
@@ -1,0 +1,25 @@
+import dash_mantine_components as dmc
+
+
+component = dmc.Stack(
+    [
+        dmc.Group(
+            [
+                dmc.Text("Fractions: 2"),
+                dmc.Rating(fractions=2, defaultValue=2, value=1)
+            ]
+        ),
+        dmc.Group(
+            [
+                dmc.Text("Fractions: 3"),
+                dmc.Rating(fractions=3, defaultValue=2, value=2.3333)
+            ]
+        ),
+        dmc.Group(
+            [
+                dmc.Text("Fractions: 4"),
+                dmc.Rating(fractions=4, defaultValue=2, value=3.75)
+            ]
+        )
+    ]
+)

--- a/docs/rating/highlightselectedonly.py
+++ b/docs/rating/highlightselectedonly.py
@@ -1,0 +1,6 @@
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    children=dmc.Rating( value=3, highlightSelectedOnly=True),
+    position="center"
+)

--- a/docs/rating/icons.py
+++ b/docs/rating/icons.py
@@ -1,0 +1,9 @@
+import dash_mantine_components as dmc
+from dash_iconify import DashIconify
+
+component = dmc.Rating(
+    value=1,
+    emptySymbol=DashIconify(icon="fa-regular:sun"),
+    fullSymbol=DashIconify(icon="fa-regular:moon")
+)
+

--- a/docs/rating/interactive.py
+++ b/docs/rating/interactive.py
@@ -1,0 +1,17 @@
+import dash_mantine_components as dmc
+
+from components.configurator import Configurator
+
+TARGET_ID = "interactive-rating"
+
+target = dmc.Group(dmc.Rating(defaultValue=2, count=5, id=TARGET_ID), position="center")
+
+configurator = Configurator(target, TARGET_ID)
+
+configurator.add_colorpicker("color", "yellow")
+configurator.add_slider("size", "sm")
+configurator.add_number_input("count",5, **{"min": 1, "max":15})
+configurator.add_number_input("value",2, **{"min": 1, "max":15})
+configurator.add_switch("highlightSelectedOnly", False)
+
+component = configurator.panel

--- a/docs/rating/rating.md
+++ b/docs/rating/rating.md
@@ -1,0 +1,52 @@
+---
+name: Rating
+description: Rating component
+endpoint: /components/rating
+package: dash_mantine_components
+---
+
+.. toc::
+
+### Introduction
+
+
+.. exec::docs.rating.interactive
+    :code: false
+
+
+### Read only
+
+.. exec::docs.rating.readonly
+
+
+### Fractions
+
+.. exec::docs.rating.fractions
+
+
+### Custom Symbol
+
+.. exec::docs.rating.icons
+
+
+### Highlight Selected Only
+
+.. exec::docs.rating.highlightselectedonly
+
+
+### Styles API
+
+| Name        | Static selector             | Description                                |
+|:------------|:----------------------------|:-------------------------------------------|
+| root        | .mantine-Rating-root        | Root element                               |
+| symbolGroup | .mantine-Rating-symbolGroup | Container for fraction symbols             |
+| input       | .mantine-Rating-input       | Input element                              |
+| label       | .mantine-Rating-label       | Label element                              |
+| symbolBody  | .mantine-Rating-symbolBody  | Element inside label that hold symbol icon |
+
+
+### Keyword Arguments
+
+#### Rating
+
+.. kwargs::Rating

--- a/docs/rating/readonly.py
+++ b/docs/rating/readonly.py
@@ -1,0 +1,6 @@
+import dash_mantine_components as dmc
+
+component = dmc.Group(
+    children=dmc.Rating(fractions=2, value=3.5, readOnly=True),
+    position="center"
+)

--- a/docs/scrollarea/horizontal.py
+++ b/docs/scrollarea/horizontal.py
@@ -1,0 +1,15 @@
+import dash_mantine_components as dmc
+from dash import html
+
+from docs.scrollarea.text import text
+
+
+component = html.Div(
+    [
+        dmc.Title("Charizard (Pokémon)", order=3),
+        dmc.ScrollArea(
+            h=250, w=350,
+            children = dmc.Paper(dmc.Text(text), withBorder=True, w=600),
+        )
+    ]
+)

--- a/docs/scrollarea/interactive.py
+++ b/docs/scrollarea/interactive.py
@@ -1,0 +1,26 @@
+import dash_mantine_components as dmc
+from dash import html
+from docs.scrollarea.text import text
+from components.configurator import Configurator
+
+TARGET_ID = "interactive-scrollarea"
+
+target = html.Div(
+    [
+        dmc.Title("Charizard (Pokémon)", order=3),
+        dmc.ScrollArea(
+            h=250, w=350,
+            children = dmc.Paper(dmc.Text(text), withBorder=True),
+            id=TARGET_ID
+        )
+    ]
+)
+
+configurator = Configurator(target, TARGET_ID)
+
+configurator.add_select("type", ["auto", "scroll", "always", "never", "hover"], "hover")
+configurator.add_number_input("scrollbarSize", 10, **{"min": 2, "max": 20, "step": 2})
+configurator.add_number_input("scrollHideDelay", 1000, **{"min": 0, "max": 4000, "step": 500})
+configurator.add_switch("offsetScrollbars", False)
+
+component = configurator.panel

--- a/docs/scrollarea/scrollarea.md
+++ b/docs/scrollarea/scrollarea.md
@@ -9,6 +9,18 @@ package: dash_mantine_components
 
 ### Introduction
 
+The ScrollArea component works well with light and dark color schemes and supports the following props:
+
+- `type` defines scrollbars behavior:
+    - `hover` – scrollbars are visible on hover
+    - `scroll` – scrollbars are visible on scroll
+    - `auto` – similar to overflow: auto – scrollbars are always visible when the content is overflowing
+    - `always` – same as auto but scrollbars are always visible regardless of whether the content is overflowing
+    - `never` – scrollbars are always hidden
+- `offsetScrollbars` – offset scrollbars with padding
+- `scrollbarSize` – scrollbar size, controls scrollbar and thumb width/height
+- `scrollHideDelay` – delay in ms to hide scrollbars, applicable only when type is hover or scroll
+
 This example has a vertical scroll bar. 
 
 .. exec::docs.scrollarea.interactive

--- a/docs/scrollarea/scrollarea.md
+++ b/docs/scrollarea/scrollarea.md
@@ -1,0 +1,54 @@
+---
+name: ScrollArea
+description: Use the ScrollArea component to customize scrollbars.
+endpoint: /components/scrollarea
+package: dash_mantine_components
+---
+
+.. toc::
+
+### Introduction
+
+This example has a vertical scroll bar. 
+
+.. exec::docs.scrollarea.interactive
+   :code: false
+
+
+This is how the ScrollArea height and width is defined in the example above 
+
+```python
+
+html.Div(
+    [
+        dmc.Title("Charizard (Pokémon)", order=3),
+        dmc.ScrollArea(
+            h=250, w=350,
+            children = dmc.Paper(dmc.Text(text), withBorder=True),        
+        )
+    ]
+)
+```
+### Horizontal scrollbars
+
+The horizontal scroll bar will be displayed when the content of the ScrollArea is wider than the ScrollArea.
+
+
+.. exec::docs.scrollarea.horizontal
+
+
+### Styles API
+
+| Name      | Static selector               | Description                                       |
+|:----------|:------------------------------|:--------------------------------------------------|
+| root      | .mantine-ScrollArea-root      | Root element                                      |
+| corner    | .mantine-ScrollArea-corner    | Corner between horizontal and vertical scrollbars |
+| viewport  | .mantine-ScrollArea-viewport  | Children wrapper                                  |
+| scrollbar | .mantine-ScrollArea-scrollbar | Scrollbar                                         |
+| thumb     | .mantine-ScrollArea-thumb     | Scrollbar thumb                                   |
+
+### Keyword Arguments
+
+#### ScrollArea
+
+.. kwargs::ScrollArea

--- a/docs/scrollarea/text.py
+++ b/docs/scrollarea/text.py
@@ -1,0 +1,8 @@
+
+text = """
+Charizard description from Bulbapedia
+
+Charizard is a draconic, bipedal Pokémon. It is primarily orange with a cream underside from the chest to the tip of its tail. It has a long neck, small blue eyes, slightly raised nostrils, and two horn-like structures protruding from the back of its rectangular head. There are two fangs visible in the upper jaw when its mouth is closed. Two large wings with blue-green undersides sprout from its back, and a horn-like appendage juts out from the top of the third joint of each wing. A single wing-finger is visible through the center of each wing membrane. Charizard's arms are short and skinny compared to its robust belly, and each limb has three white claws. It has stocky legs with cream-colored soles on each of its plantigrade feet. The tip of its long, tapering tail burns with a sizable flame.
+As Mega Charizard X, its body and legs are more physically fit, though its arms remain thin. Its skin turns black with a sky-blue underside and soles. Two spikes with blue tips curve upward from the front and back of each shoulder, while the tips of its horns sharpen, turn blue, and curve slightly upward. Its brow and claws are larger, and its eyes are now red. It has two small, fin-like spikes under each horn and two more down its lower neck. The finger disappears from the wing membrane, and the lower edges are divided into large, rounded points. The third joint of each wing-arm is adorned with a claw-like spike. Mega Charizard X breathes blue flames out the sides of its mouth, and the flame on its tail now burns blue. It is said that its new power turns it black and creates more intense flames.
+
+"""

--- a/docs/style-props/props.csv
+++ b/docs/style-props/props.csv
@@ -1,0 +1,44 @@
+Prop,CSS Property
+m,margin
+mt,marginTop
+mb,marginBottom
+ml,marginLeft
+mr,marginRight
+mx,"marginRight, marginLeft"
+my,"marginTop, marginBottom"
+p,padding
+pt,paddingTop
+pb,paddingBottom
+pl,paddingLeft
+pr,paddingRight
+px,"paddingRight, paddingLeft"
+py,"paddingTop, paddingBottom"
+bg,background
+c,color
+opacity,opacity
+ff,fontFamily
+fz,fontSize
+fw,fontWeight
+lts,letterSpacing
+ta,textAlign
+lh,lineHeight
+fs,fontStyle
+tt,textTransform
+td,textDecoration
+w,width
+miw,minWidth
+maw,maxWidth
+h,height
+mih,minHeight
+mah,maxHeight
+bgsz,background-size
+bgp,background-position
+bgr,background-repeat
+bga,background-attachment
+pos,position
+top,top
+left,left
+bottom,bottom
+right,right
+inset,inset
+display,display

--- a/docs/style-props/props.md
+++ b/docs/style-props/props.md
@@ -1,0 +1,14 @@
+---
+name: Style Props
+endpoint: "/style-props"
+head: With style props you can add responsive styles to any Mantine component that supports these props.
+description: With style props you can add responsive styles to any Mantine component that supports these props.
+dmc: false
+---
+
+##### Supported props
+
+Style props add styles to the root element, if you want to style nested elements use [Styles API](/styles-api) instead.
+
+.. exec::docs.style-props.props
+    :code: false

--- a/docs/style-props/props.py
+++ b/docs/style-props/props.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+import dash_mantine_components as dmc
+import pandas as pd
+
+from lib.utils import create_table
+
+df = pd.read_csv(Path.cwd().joinpath("docs/style-props/props.csv"), index_col=None)
+
+component = dmc.Table(create_table(df), horizontalSpacing=40, withColumnBorders=True)

--- a/docs/styles-api/button.py
+++ b/docs/styles-api/button.py
@@ -1,0 +1,8 @@
+import dash_mantine_components as dmc
+from dash_iconify import DashIconify
+
+component = dmc.Button(
+    "Settings",
+    leftIcon=DashIconify(icon="ic:baseline-settings-input-composite"),
+    styles={"root": {"fontWeight": 400}, "leftIcon": {"width": 100}},
+)

--- a/docs/styles-api/inputs.py
+++ b/docs/styles-api/inputs.py
@@ -1,0 +1,30 @@
+import dash_mantine_components as dmc
+
+component = dmc.MantineProvider(
+    inherit=True,
+    theme={
+        "components": {
+            "InputWrapper": {
+                "styles": {
+                    "label": {
+                        "color": "blue",
+                        "backgroundColor": dmc.theme.DEFAULT_COLORS["yellow"][1],
+                    },
+                }
+            },
+            "Input": {
+                "styles": {
+                    "input": {"borderColor": dmc.theme.DEFAULT_COLORS["violet"][4]}
+                },
+            },
+        }
+    },
+    children=[
+        dmc.TextInput(
+            label="TextInput with custom styles",
+            placeholder="TextInput with custom styles",
+            description="Description below the input",
+            w=300,
+        )
+    ],
+)

--- a/docs/styles-api/provider.py
+++ b/docs/styles-api/provider.py
@@ -1,0 +1,16 @@
+import dash_mantine_components as dmc
+
+component = dmc.MantineProvider(
+    inherit=True,
+    theme={
+        "components": {
+            "Badge": {
+                "styles": {
+                    "root": {"borderWidth": 1, "height": 30, "padding": 10},
+                    "inner": {"fontWeight": 500},
+                }
+            }
+        }
+    },
+    children=[dmc.Badge("Badge 1", variant="dot")],
+)

--- a/docs/styles-api/slider.py
+++ b/docs/styles-api/slider.py
@@ -1,0 +1,6 @@
+import dash_mantine_components as dmc
+
+component = dmc.Slider(
+    value=69,
+    classNames={"bar": "dmc-bar", "thumb": "dmc-thumb"},
+)

--- a/docs/styles-api/styles.md
+++ b/docs/styles-api/styles.md
@@ -1,0 +1,84 @@
+---
+name: Styles API
+endpoint: "/styles-api"
+head: With Styles API you can overwrite styles of inner elements in Mantine components with classNames or styles props.
+description: With Styles API you can overwrite styles of inner elements in Mantine components with classNames or styles props.
+dmc: false
+---
+
+##### Styling with classNames
+
+Let's say you want to make Slider component look like this:
+
+.. exec::docs.styles-api.slider
+    :code: false
+
+By default, Slider has completely different styles. One of the ways you can achieve this look is by using `classNames`
+prop. It allows you to add class names to specific elements inside the component. Just go to "Styles API" section on the
+component page, and you can find the names and descriptions of the target elements.
+
+For the above look, we will add class names to slider's bar and thumb elements.
+
+The component is defined as:
+
+```python
+import dash_mantine_components as dmc
+
+component = dmc.Slider(
+    value=69,
+    classNames={"bar": "dmc-bar", "thumb": "dmc-thumb"},
+)
+```
+
+and include this in your css file:
+
+```css
+.dmc-bar {
+    background-image: linear-gradient(to right, yellow, orange);
+}
+
+.dmc-thumb {
+    border-color: orange;
+    height: 20px;
+    width: 20px;
+    background-color: white;
+}
+```
+
+##### Styling with inline styles
+
+`styles` prop can be used similarly to style individual elements inside a component. For example, you can customize a
+dmc.Button with `styles` prop like this:
+
+.. exec::docs.styles-api.button
+
+Here again, you will have to refer to the Styles API section on the component page.
+
+##### Styles API with MantineProvider
+
+You can also use Styles API in MantineProvider with `styles` prop. All styles defined there will be added to each
+component rendered inside provider. This technique is also used to style this entire documentation.
+
+Let's say you want to apply custom styling to all your badges, here's how you can do that.
+
+.. exec::docs.styles-api.provider
+
+##### root selector
+
+If the component does not specify Styles API selectors, then in most cases you can add styles using root selector.
+
+```python
+import dash_mantine_components as dmc
+
+dmc.MantineProvider(
+    theme={"components": {"Text": {"styles": {"root": {"fontSize": 20}}}}},
+    children=[...],
+)
+```
+
+##### Example
+
+Most of the input components are based on Mantine's Input and InputWrapper components, and so you can change shared
+styles using MantineProvider:
+
+.. exec::docs.styles-api.inputs

--- a/lib/print_styles_api_table.py
+++ b/lib/print_styles_api_table.py
@@ -1,0 +1,13 @@
+"""
+copy and paste printed table to .md files
+
+create_styles_api_table(category, component)
+
+Scrapes the styles table at: f"https://v6.mantine.dev/{category}/{component}/?t=styles-api"
+"""
+
+
+from utils import create_styles_api_table
+
+print(create_styles_api_table("core", "scroll-area"))
+

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -52,6 +52,8 @@ def create_graph():
 
 def create_styles_api_table(category, component):
     url = f"https://v6.mantine.dev/{category}/{component}/?t=styles-api"
+
+    print(url)
     response = requests.get(url)
     soup = BeautifulSoup(response.content, "html.parser")
     tables = soup.find_all("table")
@@ -68,7 +70,9 @@ def create_styles_api_table(category, component):
                 row.append(td.text.strip())
             if row:
                 rows.append(row)
+        print(rows, headers)
         df = pd.DataFrame(rows, columns=headers)
         dataframes.append(df)
+    print(df)
     markdown_table = df.to_markdown(index=False)
     return markdown_table

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,5 +1,7 @@
 import random
-
+import requests
+import pandas as pd
+from bs4 import BeautifulSoup
 import dash_mantine_components as dmc
 from dash import html, dcc
 import plotly.graph_objects as go
@@ -45,3 +47,28 @@ def create_figure():
 
 def create_graph():
     return dcc.Graph(figure=create_figure(), config={"displayModeBar": False})
+
+
+
+def create_styles_api_table(category, component):
+    url = f"https://v6.mantine.dev/{category}/{component}/?t=styles-api"
+    response = requests.get(url)
+    soup = BeautifulSoup(response.content, "html.parser")
+    tables = soup.find_all("table")
+    dataframes = []
+    df=pd.DataFrame()
+    for table in tables:
+        headers = []
+        for th in table.find_all("th"):
+            headers.append(th.text.strip())
+        rows = []
+        for tr in table.find_all("tr"):
+            row = []
+            for td in tr.find_all("td"):
+                row.append(td.text.strip())
+            if row:
+                rows.append(row)
+        df = pd.DataFrame(rows, columns=headers)
+        dataframes.append(df)
+    markdown_table = df.to_markdown(index=False)
+    return markdown_table


### PR DESCRIPTION
Fixed nav header links
Added side bar nav  

Added pages:
  - getting started
  - styles api
  - style props
  - ScrollArea
  - Rating
  - PinInput
  - ColorInput
  - DateInput
  - AspectRatio
  - Flex
  - Popover
  - Mark

@snehilvj :
- In this [commit](https://github.com/snehilvj/dmc-docs/pull/40/commits/a158eeb52d7056ea4839e644d984007fc3da9a53) I added a way to generate the Styles API markdown table.  I just copy and past it into the .md file.  It works fine, but this can be deleted if you were  planning a better way to do this. 
 **update** - doesn't seem to work for all pages - might need to use selenium

- What's the syntax for nested lists in .md files?   In [this commit](https://github.com/snehilvj/dmc-docs/pull/40/commits/b970e781deef8cc700f2b6782c7fd5b753cbc831),  only the top level is rendered.  The items under `type` aren't displayed. 

- In the Rating component, the  `defalutValue` prop has no effect.  What does it mean to have an "uncontrolled component"?

- In the PinInput coomponent, the [regex type](https://v6.mantine.dev/core/pin-input/#regex-type) does not work so I excluded the example for now.  Also the `inputMode` prop is missing

- in the DateInput,  when `clearable=True` you can't change the date with the backspace key. 

-  In the Popover Inline example, the only way I could make it inline was to use a `dmc.Flex` component.  Is there a better way?

- I wasn't able to make the `AppShell` component work.  It's not allowing components as props.  Try running this:

```

import dash_mantine_components as dmc
from dash import Dash

app = Dash(__name__)

header=dmc.Header("My Header", height=60, p="xs")
navbar=dmc.Navbar("my Navbar", width={"base": 300}, height=500, p="xs")

app.layout = dmc.AppShell(
    children=["App content goes here"],
     navbar=[navbar],
     header=[header],
)

if __name__ == "__main__":
    app.run_server(debug=True)


```
