### PR TITLE
Fixed navbar media query

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -25,7 +25,7 @@ input:invalid {
     }
 }
 
-@media only screen and (max-width: 1200px) {
+@media only screen and (max-width: 1199px) {
     #components-navbar {
         display: none;
     }


### PR DESCRIPTION
Hey there,

I noticed that the media query is off by 1 pixel. Since the navbar is hidden when the screen is smaller than 1200px, it should be 1199px here. There is a weird glitch if your browser is at exactly 1200 pixels. Not a big deal but wanted to let you know :) 