### PR TITLE
fixes content display on small screens

### DIFF
--- a/lib/configurator.py
+++ b/lib/configurator.py
@@ -159,7 +159,7 @@ class Configurator:
 
         return dmc.Grid(
             [
-                dmc.GridCol(self.target, span="auto", p=20, miw=400),
+                dmc.GridCol(self.target, span={"sm": 12, "md": "auto"}, p=20),
                 dmc.GridCol(
                     dmc.Stack(self.controls, gap="md", maw="100%", w=240, p=20),
                     span="content",


### PR DESCRIPTION
Fixes the overflowing content on interactive examples

![image](https://github.com/snehilvj/dmc-docs/assets/72614349/28ab9890-77fc-476b-b2b0-fd2e4ba5a6fb)
