### PR TITLE
added theme switch example

### DIFF
--- a/components/appshell.py
+++ b/components/appshell.py
@@ -46,7 +46,6 @@ def create_appshell(data):
             },
         },
         children=[
-            dcc.Store(id="theme-store", storage_type="local", data="light"),
             dcc.Location(id="url", refresh="callback-nav"),
             dmc.NotificationProvider(zIndex=2000),
             dmc.AppShell(
@@ -77,16 +76,6 @@ def create_appshell(data):
 clientside_callback(
     """
     function(data) {
-        return data
-    }
-    """,
-    Output("m2d-mantine-provider", "forceColorScheme"),
-    Input("theme-store", "data"),
-)
-
-clientside_callback(
-    """
-    function(data) {
         const box = document.getElementById("ethical-ads-box");
         if (data === "dark") {
             box.classList.add("dark");
@@ -97,17 +86,22 @@ clientside_callback(
     }
     """,
     Output("ethical-ads-box", "className"),
-    Input("theme-store", "data"),
+    Input("m2d-mantine-provider", "forceColorScheme"),
 )
 
 clientside_callback(
     """
-    function(n_clicks, data) {
-        return data === "dark" ? "light" : "dark";
+    function(n_clicks, theme) {        
+        dash_clientside.set_props("m2d-mantine-provider", {
+            forceColorScheme: theme === "dark" ? "light" : "dark"
+        });
+        return dash_clientside.no_update
     }
     """,
-    Output("theme-store", "data"),
+    Output("m2d-mantine-provider", "forceColorScheme"),
     Input("color-scheme-toggle", "n_clicks"),
-    State("theme-store", "data"),
+    State("m2d-mantine-provider", "forceColorScheme"),
     prevent_initial_call=True,
 )
+
+

--- a/docs/mantineprovider/mantineprovider.md
+++ b/docs/mantineprovider/mantineprovider.md
@@ -139,6 +139,52 @@ app.layout = dmc.MantineProvider(
  )
 ```
 
+### Theme Switch
+
+This minimal example shows how to toggle between light and dark modes, similar to the theme switcher used in these docs.
+
+```python
+
+import dash_mantine_components as dmc
+from dash_iconify import DashIconify
+from dash import Dash, Input, Output, State, callback, _dash_renderer
+_dash_renderer._set_react_version("18.2.0")
+
+theme_toggle = dmc.ActionIcon(
+    [
+        dmc.Paper(DashIconify(icon="radix-icons:sun", width=25), darkHidden=True),
+        dmc.Paper(DashIconify(icon="radix-icons:moon", width=25), lightHidden=True),
+    ],
+    variant="transparent",
+    color="yellow",
+    id="color-scheme-toggle",
+    size="lg",
+    ms="auto",
+)
+
+app = Dash()
+
+app.layout = dmc.MantineProvider(
+    [theme_toggle, dmc.Text("Your page content")],
+    id="mantine-provider",
+    forceColorScheme="light",
+)
+
+
+@callback(
+    Output("mantine-provider", "forceColorScheme"),
+    Input("color-scheme-toggle", "n_clicks"),
+    State("mantine-provider", "forceColorScheme"),
+    prevent_initial_call=True,
+)
+def switch_theme(_, theme):
+    return "dark" if theme == "light" else "light"
+
+
+if __name__ == "__main__":
+    app.run(debug=True)
+```
+
 ### Default theme
 
 Default theme is available as `dmc.DEFAULT_THEME`. It includes all theme properties with default values. 


### PR DESCRIPTION
Added a minimal example of a theme switch component similar to the one in the docs.  
 - used a regular instead of clientside callback
 - used the `darkHidden` and `lightHidden` props for the theme switch icons so that no custom CSS is required

For the AppShell in the docs, simplified the clientside callback to use set_props and eliminated the need for the dcc.Store
