### PR TITLE
Added autoplay option section to Carousel docs

### DIFF
--- a/docs/carousel/autoplay.py
+++ b/docs/carousel/autoplay.py
@@ -1,0 +1,11 @@
+import dash_mantine_components as dmc
+
+component = dmc.Carousel(
+    [
+        dmc.CarouselSlide(dmc.Center("Slide-1", bg="blue", c="white", p=60)),
+        dmc.CarouselSlide(dmc.Center("Slide-2", bg="blue", c="white", p=60)),
+        dmc.CarouselSlide(dmc.Center("Slide-3", bg="blue", c="white", p=60)),
+    ],
+    id="carousel-simple",
+    autoplay=True # Default delay is 2000ms
+)

--- a/docs/carousel/autoplay.py
+++ b/docs/carousel/autoplay.py
@@ -7,5 +7,6 @@ component = dmc.Carousel(
         dmc.CarouselSlide(dmc.Center("Slide-3", bg="blue", c="white", p=60)),
     ],
     id="carousel-simple",
+    loop=True,
     autoplay=True # Default delay is 2000ms
 )

--- a/docs/carousel/autoplay.py
+++ b/docs/carousel/autoplay.py
@@ -8,5 +8,5 @@ component = dmc.Carousel(
     ],
     id="carousel-simple",
     loop=True,
-    autoplay=True # Default delay is 2000ms
+    autoplay=True # Default delay is 4000ms
 )

--- a/docs/carousel/carousel.md
+++ b/docs/carousel/carousel.md
@@ -73,6 +73,11 @@ You can replace default next/previous controls icons with any component:
 
 .. exec::docs.carousel.controls_icons
 
+### Autoplay
+Enable autoplay by setting `autoplay=True` or by passing in a `dict` with options. Refer to [Embla Carousel Autoplay Options](https://www.embla-carousel.com/plugins/autoplay/#options) to learn more.
+
+.. exec::docs.carousel.autoplay
+
 ### Styles API
 
 Carousel supports Styles API, you can add styles to any inner element of the component with `classNames` prop. Refer to the  [Styles API documentation](/styles-api) to learn more.


### PR DESCRIPTION
These are the docs for the new `autoplay` option for the `Carousel` component [[PR#316](https://github.com/snehilvj/dash-mantine-components/pull/316)].