### PR TITLE
Fix time input

### DIFF
--- a/docs/drawer/drawer.md
+++ b/docs/drawer/drawer.md
@@ -40,17 +40,33 @@ You can customize transition, timing function and duration for Drawer transition
 
 ### Styles API
 
-| Name    | Static selector         | Description                                                           |
-|:--------|:------------------------|:----------------------------------------------------------------------|
-| root    | .mantine-Divider-root   | Root element                                                          |
-| label   | .mantine-Divider-label  | Label element                                                         || root | .mantine-Drawer-root | Root element |
-| inner   | .mantine-Drawer-inner   | Element used to center modal, has fixed position, takes entire screen |
-| content | .mantine-Drawer-content | `Drawer.Content` root element                                         |
-| header  | .mantine-Drawer-header  | Contains title and close button                                       |
-| overlay | .mantine-Drawer-overlay | Overlay displayed under the `Drawer.Content`                          |
-| title   | .mantine-Drawer-title   | Drawer title (h2 tag), displayed in the header                        |
-| body    | .mantine-Drawer-body    | Drawer body, displayed after header                                   |
-| close   | .mantine-Drawer-close   | Close button                                                          |
+#### Drawer Selectors
+
+| Selector  | Static selector             | Description                                                             |
+| --------- | --------------------------- | ----------------------------------------------------------------------- |
+| `root`    | `.mantine-Drawer-root`       | Root element                                                            |
+| `inner`   | `.mantine-Drawer-inner`      | Element used to center modal, has fixed position, takes entire screen    |
+| `content` | `.mantine-Drawer-content`    | Drawer.Content root element                                              |
+| `header`  | `.mantine-Drawer-header`     | Contains title and close button                                          |
+| `overlay` | `.mantine-Drawer-overlay`    | Overlay displayed under the Drawer.Content                               |
+| `title`   | `.mantine-Drawer-title`      | Drawer title (`h2` tag), displayed in the header                         |
+| `body`    | `.mantine-Drawer-body`       | Drawer body, displayed after header                                      |
+| `close`   | `.mantine-Drawer-close`      | Close button                                                            |
+
+
+
+#### Drawer CSS variables
+
+
+| Selector | Variable          | Description                              |
+|----------|-------------------|------------------------------------------|
+| root     | --drawer-offset    | Controls margin of Drawer.Content        |
+|          | --drawer-size      | Controls width of Drawer.Content         |
+|          | --drawer-flex      | Controls flex property of Drawer.Content |
+|          | --drawer-align     | Controls align-items property of Drawer.Content |
+|          | --drawer-justify   | Controls justify-content property of Drawer.Content |
+|          | --drawer-height    | Controls height property of Drawer.Content |
+
 
 ### Keyword Arguments
 

--- a/docs/timeinput/simple.py
+++ b/docs/timeinput/simple.py
@@ -8,7 +8,7 @@ component = dmc.Group(
         dmc.TimeInput(
             label="What time is it now?",
             withSeconds=True,
-            value=datetime.datetime.now(),
+            value="23:15:45",
         ),
     ],
 )

--- a/docs/timeinput/timeinput.md
+++ b/docs/timeinput/timeinput.md
@@ -3,15 +3,14 @@ name: TimeInput
 description: Use the TimeInput component to capture time input from user.
 endpoint: /components/timeinput
 package: dash_mantine_components
-category: Inputs
+category: Date Pickers
 ---
 
 .. toc::
 
 ### Simple Example
 
-This is a simple example of the TimeInput. You can enter a valid time string or use the date object from datetime 
-library.
+This is a simple example of the TimeInput. You can enter a valid time string such as hh:mm:ss.
 
 Use the  `withSeconds` prop to display seconds.
 


### PR DESCRIPTION
Fixed the time input
 - removed the datetime object as it causes an error in the console
 - placed it in the Date Picker section rather than the Input section to match the upstream Mantine docs
 

Fixed the formatting of the Markdown table in the Drawer