### PR TITLE
workaround for tooltip children width

### DIFF
--- a/docs/progress/floatingtooltip.py
+++ b/docs/progress/floatingtooltip.py
@@ -1,0 +1,34 @@
+import dash_mantine_components as dmc
+
+component = dmc.ProgressRoot(
+    [
+        dmc.FloatingTooltip(
+            dmc.ProgressSection(
+                dmc.ProgressLabel("Documents"),
+                value=33,
+                color="cyan",
+            ),
+            label="Documents – 33Gb",
+            boxWrapperProps={"display": "contents"},
+        ),
+        dmc.FloatingTooltip(
+            dmc.ProgressSection(
+                dmc.ProgressLabel("Photos"),
+                value=28,
+                color="pink",
+            ),
+            label="Photos – 28Gb",
+            boxWrapperProps={"display": "contents"},
+        ),
+        dmc.FloatingTooltip(
+            dmc.ProgressSection(
+                dmc.ProgressLabel("Other"),
+                value=25,
+                color="orange",
+            ),
+            label="Other – 15Gb",
+            boxWrapperProps={"display": "contents"},
+        ),
+    ],
+    size=40,
+)

--- a/docs/progress/progress.md
+++ b/docs/progress/progress.md
@@ -52,18 +52,27 @@ Multiple sections can be displayed instead of just one single bar.
 .. exec::docs.progress.sections
 
 
-### Limitations - with Tooltip
+### Limitations - Tooltips
 
 There is a limitation in Dash that makes it challenging to style the width of some tooltip children. For more details, see [GitHub #319.](https://github.com/snehilvj/dash-mantine-components/issues/319)
 
-Tooltip children are wrapped in a `Box` with a default width of `fit-content`, which may override the width defined in the children. To work around this, you can set the width using `boxWrapperProps`.
+Tooltip children are wrapped in a `Box` with a default style of `{'width': 'fit-content'}`, which may override the width defined in the children. To work around this, you can set the width using `boxWrapperProps`.
 
 `boxWrapperProps` is a dictionary of style properties passed to the `Box` that wraps the tooltip children.
+
+#### With Tooltip
 
 In this example, the width of the `ProgressSection` is set to 100%, and the width of each section is defined using the `boxWrapperProps`.
 
 
 .. exec::docs.progress.tooltip
+
+#### With FloatingTooltip
+
+Another even better workaround is to use `FloatingTooltips`.  In this case, set `boxWrapperProps={'display': 'contents'}`
+
+
+.. exec::docs.progress.floatingtooltip
 
 
 ### Styles API


### PR DESCRIPTION
added floating tooltip example