### PR TITLE
fix YearPickerInput and MonthPickerInput modals z-index

### DIFF
--- a/docs/monthpickerinput/modal.py
+++ b/docs/monthpickerinput/modal.py
@@ -4,4 +4,5 @@ component = dmc.MonthPickerInput(
     dropdownType="modal",
     label="Pick date (picker in modal)",
     placeholder="Pick date",
+    modalProps={"zIndex": 2000},
 )

--- a/docs/yearpickerinput/modal.py
+++ b/docs/yearpickerinput/modal.py
@@ -4,4 +4,5 @@ component = dmc.YearPickerInput(
     dropdownType="modal",
     label="Pick date (picker in modal)",
     placeholder="Pick date",
+    modalProps={"zIndex": 2000},
 )


### PR DESCRIPTION
Fixes #77

- [X] Modal in `YearPickerInput`
- [X] Modal in `MonthPickerInput`

![image](https://github.com/user-attachments/assets/da048aa1-3e8a-41e8-bec0-39c79169fcf1) _- MonthPickerInput screenshot_
