### PR TITLE
Dmc pr 368

### DIFF
--- a/docs/areachart/areachart.md
+++ b/docs/areachart/areachart.md
@@ -307,12 +307,25 @@ Use `referenceLines` prop to render reference lines. Reference lines are always 
 .. exec::docs.areachart.referencelines
 
 ### clickData
-You can use the  `clickData` property in a callback to get data from latest click event.
+Use the `clickData` property in a callback to retrieve data from the most recent click event.
+To get the name of the clicked series, use the `clickSeriesName` property.
 
 .. exec::docs.areachart.clickdata
 
 
+### hoverData
+Use the `hoverData` property in a callback to retrieve data from the most recent hover event.
+To get the name of the hovered series, use the `hoverSeriesName` property.
+
+.. exec::docs.areachart.hoverdata
+
+### highlightHover
+
+Set `highlightHover=True` to highlight the series when hovered, mirroring the behavior of hovering over chart legend items.
 ### Styles API
+
+
+.. exec::docs.areachart.highlighthover
 
 This component supports [Styles API](/styles-api). With Styles API, you can customize styles of any inner element.
 For more information on styling components,  please also refer to the [Mantine Styles](https://mantine.dev/styles/styles-overview/) documentation.

--- a/docs/areachart/areachart.md
+++ b/docs/areachart/areachart.md
@@ -322,6 +322,9 @@ To get the name of the hovered series, use the `hoverSeriesName` property.
 ### highlightHover
 
 Set `highlightHover=True` to highlight the series when hovered, mirroring the behavior of hovering over chart legend items.
+
+.. exec::docs.areachart.highlighthover
+
 ### Styles API
 
 

--- a/docs/areachart/highlighthover.py
+++ b/docs/areachart/highlighthover.py
@@ -1,0 +1,15 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.AreaChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    type="stacked",
+    series=[
+        {"name": "Apples", "color": "indigo.6"},
+        {"name": "Oranges", "color": "blue.6"},
+        {"name": "Tomatoes", "color": "teal.6"},
+    ],
+    highlightHover=True
+)

--- a/docs/areachart/hoverdata.py
+++ b/docs/areachart/hoverdata.py
@@ -6,7 +6,7 @@ from .data import data
 component = dmc.Group(
     [
         dmc.AreaChart(
-            id="figure-areachart",
+            id="figure-areachart-hover",
             h=300,
             dataKey="date",
             data=data,
@@ -17,17 +17,18 @@ component = dmc.Group(
                 {"name": "Tomatoes", "color": "teal.6"},
             ],
         ),
-        dmc.Text(id="clickdata-areachart1"),
-        dmc.Text(id="clickdata-areachart2"),
+        dmc.Text(id="hoverdata-areachart1"),
+        dmc.Text(id="hoverdata-areachart2"),
     ]
 )
 
 
 @callback(
-    Output("clickdata-areachart1", "children"),
-    Output("clickdata-areachart2", "children"),
-    Input("figure-areachart", "clickData"),
-    Input("figure-areachart", "clickSeriesName"),
+    Output("hoverdata-areachart1", "children"),
+    Output("hoverdata-areachart2", "children"),
+    Input("figure-areachart-hover", "hoverData"),
+    Input("figure-areachart-hover", "hoverSeriesName"),
 )
 def update(data, name):
-    return f"clickData:  {data}", f"clickSeriesName: {name}"
+    return f"hoverData:  {data}", f"hoverSeriesName: {name}"
+

--- a/docs/barchart/barchart.md
+++ b/docs/barchart/barchart.md
@@ -207,9 +207,23 @@ To display value above each bar, set `withBarValueLabel=True`:
 .. exec::docs.barchart.bar_value_label
 
 ### clickData
-You can use the  `clickData` property in a callback to get data from latest click event.
+Use the `clickData` property in a callback to retrieve data from the most recent click event.
+To get the name of the clicked series, use the `clickSeriesName` property.
 
 .. exec::docs.barchart.clickdata
+
+
+### hoverData
+Use the `hoverData` property in a callback to retrieve data from the most recent hover event.
+To get the name of the hovered series, use the `hoverSeriesName` property.
+
+.. exec::docs.barchart.hoverdata
+
+### highlightHover
+
+Set `highlightHover=True` to highlight the series when hovered, mirroring the behavior of hovering over chart legend items.
+
+.. exec::docs.barchart.highlighthover
 
 ### Styles API
 

--- a/docs/barchart/highlighthover.py
+++ b/docs/barchart/highlighthover.py
@@ -1,0 +1,17 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.BarChart(
+    h=300,
+    dataKey="month",
+    data=data,
+    type="stacked",
+    series=[
+        {"name": "Smartphones", "color": "violet.6"},
+        {"name": "Laptops", "color": "blue.6"},
+        {"name": "Tablets", "color": "teal.6"},
+    ],
+    withLegend=True,
+    withTooltip=False,
+    highlightHover=True
+)

--- a/docs/barchart/hoverdata.py
+++ b/docs/barchart/hoverdata.py
@@ -5,7 +5,7 @@ from .data import data
 component = dmc.Group(
     [
         dmc.BarChart(
-            id="figure-barchart",
+            id="figure-barchart-hover",
             h=300,
             dataKey="month",
             data=data,
@@ -18,17 +18,17 @@ component = dmc.Group(
             withLegend=True,
             withTooltip=False,
         ),
-        dmc.Text(id="clickdata-barchart1"),
-        dmc.Text(id="clickdata-barchart2"),
+        dmc.Text(id="hoverdata-barchart1"),
+        dmc.Text(id="hoverdata-barchart2"),
     ]
 )
 
 @callback(
-    Output("clickdata-barchart1", "children"),
-    Output("clickdata-barchart2", "children"),
-    Input("figure-barchart", "clickData"),
-    Input("figure-barchart", "clickSeriesName"),
+    Output("hoverdata-barchart1", "children"),
+    Output("hoverdata-barchart2", "children"),
+    Input("figure-barchart-hover", "hoverData"),
+    Input("figure-barchart-hover", "hoverSeriesName"),
 )
 def update(data, name):
-    return f"clickData:  {data}", f"clickSeriesName: {name}"
+    return f"hoverData:  {data}", f"hoverSeriesName: {name}"
 

--- a/docs/bubblechart/bubblechart.md
+++ b/docs/bubblechart/bubblechart.md
@@ -1,0 +1,84 @@
+---
+name: BubbleChart
+description: Bubble Chart component
+endpoint: /components/bubblechart
+package: dash_mantine_components
+category: Charts
+---
+
+.. toc::
+
+### Usage
+
+
+.. exec::docs.bubblechart.simple
+
+
+### Data
+
+Here is the data used in all the examples on this page:
+
+```python
+data = [
+    {"hour": "08:00", "index": 1, "value": 150},
+    {"hour": "10:00", "index": 1, "value": 166},
+    {"hour": "12:00", "index": 1, "value": 170},
+    {"hour": "14:00", "index": 1, "value": 150},
+    {"hour": "16:00", "index": 1, "value": 200},
+    {"hour": "18:00", "index": 1, "value": 400},
+    {"hour": "20:00", "index": 1, "value": 100},
+    {"hour": "22:00", "index": 1, "value": 160},
+]
+```
+
+### Change color
+
+You can reference colors from theme the same way as in other components, for example, `blue`, `red.5`, `orange.7`, etc. Any valid CSS color value is also accepted.
+
+.. exec::docs.bubblechart.interactive
+    :code: false
+
+### Remove tooltip
+To remove tooltip, set `withTooltip=False`. It also removes the cursor line and disables interactions with the chart.
+
+.. exec::docs.bubblechart.remove_tooltip
+
+### clickData 
+
+Use the `clickData` property in a callback to retrieve data from the most recent click event. 
+
+.. exec::docs.bubblechart.clickdata
+
+### hoverData 
+
+Use the `hoverData` property in a callback to retrieve data from the most recent hover event. 
+
+.. exec::docs.bubblechart.hoverdata
+
+### Styles API
+
+This component supports [Styles API](/styles-api). With Styles API, you can customize styles of any inner element.
+For more information on styling components,  please also refer to the [Mantine Styles](https://mantine.dev/styles/styles-overview/) documentation.
+
+#### BubbleChart selectors 
+
+| Selector | Static selector              | Description                |
+|----------|------------------------------|----------------------------|
+| root     | .mantine-BubbleChart-root    | Root element               |
+| axis     | .mantine-BubbleChart-axis    | X and Y axis of the chart  |
+| tooltip  | .mantine-BubbleChart-tooltip | Tooltip root element       |
+
+
+#### BubbleChart CSS variables
+
+| Selector | Variable             | Description                                 |
+|----------|-----------------------|---------------------------------------------|
+| root     | --chart-grid-color    | Controls color of the grid and cursor lines |
+|          | --chart-text-color    | Controls color of the axis labels           |
+
+
+### Keyword Arguments
+
+#### BubbleChart
+
+.. kwargs::BubbleChart

--- a/docs/bubblechart/clickdata.py
+++ b/docs/bubblechart/clickdata.py
@@ -1,0 +1,29 @@
+from dash import callback, Input, Output
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.Group(
+    [
+        dmc.BubbleChart(
+            id="figure-bubblechart",
+            gridColor="gray.5",
+            textColor="gray.9",
+            h=60,
+            data=data,
+            range=[16, 225],
+            label="Sales/hour",
+            color="lime.6",
+            dataKey={"x": "hour", "y": "index", "z": "value"}
+        ),
+        dmc.Text(id="clickdata-bubblechart"),
+
+    ]
+)
+
+@callback(
+    Output("clickdata-bubblechart", "children"),
+    Input("figure-bubblechart", "clickData"),
+)
+def update(data):
+    return f"clickData:  {data}"
+

--- a/docs/bubblechart/data.py
+++ b/docs/bubblechart/data.py
@@ -1,0 +1,10 @@
+data = [
+    {"hour": "08:00", "index": 1, "value": 150},
+    {"hour": "10:00", "index": 1, "value": 166},
+    {"hour": "12:00", "index": 1, "value": 170},
+    {"hour": "14:00", "index": 1, "value": 150},
+    {"hour": "16:00", "index": 1, "value": 200},
+    {"hour": "18:00", "index": 1, "value": 400},
+    {"hour": "20:00", "index": 1, "value": 100},
+    {"hour": "22:00", "index": 1, "value": 160},
+]

--- a/docs/bubblechart/hoverdata.py
+++ b/docs/bubblechart/hoverdata.py
@@ -1,0 +1,29 @@
+from dash import callback, Input, Output
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.Group(
+    [
+        dmc.BubbleChart(
+            id="figure-bubblechart-hover",
+            gridColor="gray.5",
+            textColor="gray.9",
+            h=60,
+            data=data,
+            range=[16, 225],
+            label="Sales/hour",
+            color="lime.6",
+            dataKey={"x": "hour", "y": "index", "z": "value"}
+        ),
+        dmc.Text(id="hoverdata-bubblechart"),
+
+    ]
+)
+
+@callback(
+    Output("hoverdata-bubblechart", "children"),
+    Input("figure-bubblechart-hover", "hoverData"),
+)
+def update(data):
+    return f"hoverData:  {data}"
+

--- a/docs/bubblechart/interactive.py
+++ b/docs/bubblechart/interactive.py
@@ -1,0 +1,22 @@
+import dash_mantine_components as dmc
+from .data import data
+
+from lib.configurator import Configurator
+
+target = dmc.BubbleChart(
+    gridColor="gray.5",
+    textColor="gray.9",
+    h=60,
+    data=data,
+    range=[16, 225],
+    label="Sales/hour",
+    color="lime.6",
+    dataKey={"x": "hour", "y": "index", "z": "value"}
+)
+
+configurator = Configurator(target)
+
+
+configurator.add_colorpicker("color", "blue")
+
+component = configurator.panel

--- a/docs/bubblechart/remove_tooltip.py
+++ b/docs/bubblechart/remove_tooltip.py
@@ -1,0 +1,15 @@
+import dash_mantine_components as dmc
+from .data import data
+
+
+component = dmc.BubbleChart(
+    gridColor="gray.5",
+    textColor="gray.9",
+    h=60,
+    data=data,
+    range=[16, 225],
+    label="Sales/hour",
+    color="lime.6",
+    dataKey={"x": "hour", "y": "index", "z": "value"},
+    withTooltip=False
+)

--- a/docs/bubblechart/simple.py
+++ b/docs/bubblechart/simple.py
@@ -1,0 +1,14 @@
+import dash_mantine_components as dmc
+from .data import data
+
+
+component = dmc.BubbleChart(
+    gridColor="gray.5",
+    textColor="gray.9",
+    h=60,
+    data=data,
+    range=[16, 225],
+    label="Sales/hour",
+    color="lime.6",
+    dataKey={"x": "hour", "y": "index", "z": "value"}
+)

--- a/docs/compositechart/axislabels.py
+++ b/docs/compositechart/axislabels.py
@@ -1,0 +1,30 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.BarChart(
+    h=300,
+    dataKey="month",
+    data=data,
+    type="stacked",
+    xAxisLabel="Date",
+    yAxisLabel="Amount",
+    series=[
+        {"name": "Smartphones", "color": "violet.6"},
+        {"name": "Laptops", "color": "blue.6"},
+        {"name": "Tablets", "color": "teal.6"},
+    ],
+)
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    xAxisLabel="Date",
+    yAxisLabel="Amount",
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)

--- a/docs/compositechart/chartcolor.py
+++ b/docs/compositechart/chartcolor.py
@@ -1,0 +1,13 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    withLegend=True,
+    maxBarWidth=30,
+    series=[
+        {"name": "Apples", "color": "blue", "type": "line"},
+    ]
+)

--- a/docs/compositechart/clickdata.py
+++ b/docs/compositechart/clickdata.py
@@ -1,0 +1,33 @@
+from dash import callback, Input, Output
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.Group(
+    [
+        dmc.CompositeChart(
+            id="figure-compositechart",
+            h=300,
+            data=data,
+            dataKey="date",
+            withLegend=True,
+            maxBarWidth=30,
+            series=[
+                {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+                {"name": "Apples", "color": "red.8", "type": "line"},
+                {"name": "Oranges", "color": "yellow.8", "type": "area"},
+            ]
+        ),
+        dmc.Text(id="clickdata-compositechart1"),
+        dmc.Text(id="clickdata-compositechart2"),
+    ]
+)
+
+@callback(
+    Output("clickdata-compositechart1", "children"),
+    Output("clickdata-compositechart2", "children"),
+    Input("figure-compositechart", "clickData"),
+    Input("figure-compositechart", "clickSeriesName"),
+)
+def update(data, name):
+    return f"clickData:  {data}", f"clickSeriesName: {name}"
+

--- a/docs/compositechart/compositechart.md
+++ b/docs/compositechart/compositechart.md
@@ -212,6 +212,8 @@ To get the name of the hovered series, use the `hoverSeriesName` property.
 
 Set `highlightHover=True` to highlight the series when hovered, mirroring the behavior of hovering over chart legend items.
 
+.. exec::docs.compositechart.highlighthover
+
 
 ### Styles API
 

--- a/docs/compositechart/compositechart.md
+++ b/docs/compositechart/compositechart.md
@@ -1,0 +1,261 @@
+---
+name: CompositeChart
+description: Composed chart with support for Area, Bar and Line charts
+endpoint: /components/compositechart
+package: dash_mantine_components
+category: Charts
+---
+
+.. toc::
+
+### Introduction
+
+.. exec::docs.compositechart.interactive
+    :code: false
+
+```python
+
+import dash_mantine_components as dmc
+from .data import data
+
+dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    withLegend=True,
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)
+
+```
+
+### Data
+
+Here is the data used in all the examples on this page:
+
+```python
+data = [
+    {
+        "date": "Mar 22",
+        "Apples": 2890,
+        "Oranges": 2338,
+        "Tomatoes": 2452,
+    },
+    {
+        "date": "Mar 23",
+        "Apples": 2756,
+        "Oranges": 2103,
+        "Tomatoes": 2402,
+    },
+    {
+        "date": "Mar 24",
+        "Apples": 3322,
+        "Oranges": 986,
+        "Tomatoes": 1821,
+    },
+    {
+        "date": "Mar 25",
+        "Apples": 3470,
+        "Oranges": 2108,
+        "Tomatoes": 2809,
+    },
+    {
+        "date": "Mar 26",
+        "Apples": 3129,
+        "Oranges": 1726,
+        "Tomatoes": 2290,
+    },
+]
+
+```
+
+
+### Legend
+To display chart legend, set `withLegend` prop. When one of the items in the legend is hovered, the corresponding data
+series is highlighted in the chart.
+
+.. exec::docs.compositechart.legend
+
+
+### Legend position
+You can pass props down to recharts `Legend` component with `legendProps` prop. For example, setting the following will
+render the legend at the bottom of the chart and set its height to 50px.
+
+```python
+legendProps={"verticalAlign": "bottom", "height": 50} 
+```
+
+.. exec::docs.compositechart.legendposition
+
+
+### Series labels
+By default, series `name` is used as a label. To change it, set `label` property in `series` object:
+
+.. exec::docs.compositechart.serieslabels
+
+### Points labels
+
+To display labels on data points, set `withPointLabels=True`. This feature is supported only for Line and Area charts:
+
+.. exec::docs.compositechart.pointslabels
+
+### X and Y axis props
+Use `xAxisProps` and `yAxisProps` to pass props down to recharts `XAxis` and `YAxis` components. For example, these
+props can be used to change orientation of axis:
+
+.. exec::docs.compositechart.xyaxis
+
+### Axis labels
+Use `xAxisLabel` and `yAxisLabel` props to display axis labels:
+
+.. exec::docs.compositechart.axislabels
+
+
+### X axis offset
+Use `xAxisProps` to set padding between the charts ends and the x-axis:
+
+.. exec::docs.compositechart.xaxisoffset
+
+### Y axis scale
+Use `yAxisProps` to change domain of the Y axis. For example, if you know that your data will always be in the range
+of 0 to 150, you can set domain to `[0, 150]`:
+
+.. exec::docs.compositechart.yaxisscale
+
+
+### Chart color
+
+You can reference colors from theme the same way as in other components, for example, `blue`, `red.5`, `orange.7`, etc. Any valid CSS color value is also accepted.
+
+.. exec::docs.compositechart.chartcolor
+
+### Stroke dash array
+Set `strokeDasharray` prop to control the stroke dash array of the grid and cursor lines. The value represent the lengths of alternating dashes and gaps. For example, strokeDasharray="10 5" will render a dashed line with 10px dashes and 5px gaps.
+
+.. exec::docs.compositechart.strokedasharray
+
+
+### Tooltip animation
+By default, tooltip animation is disabled. To enable it, set `tooltipAnimationDuration` prop to a number of milliseconds to animate the tooltip position change.
+
+.. exec::docs.compositechart.tooltipanimation
+
+
+
+### Units
+Set `unit` prop to render a unit label next to the y-axis ticks and tooltip values:
+
+.. exec::docs.compositechart.units
+
+### Remove tooltip
+To remove tooltip, set `withTooltip=false`. It also removes the cursor line and disables interactions with the chart.
+
+.. exec::docs.compositechart.removetooltip
+
+### Customize dots
+Use `dotProps` to pass props down to recharts dot in regular state and `activeDotProps` to pass props down to recharts
+dot in active state (when cursor is over the current series).
+
+.. exec::docs.compositechart.customizedots
+
+### Stroke width
+Use `strokeWidth` prop to control the stroke width of all areas/lines:
+
+
+.. exec::docs.compositechart.strokewidth
+
+
+### Sync multiple charts
+You can pass props down to recharts [ComposedChart](https://recharts.org/en-US/api/ComposedChart) component with
+`composedChartProps` prop. For example, setting the following will sync tooltip of multiple `CompositeChart` components
+with the same `syncId` prop.
+
+```python 
+composedChartProps={"syncId": "any-id"}
+```
+
+.. exec::docs.compositechart.sync
+
+### Dashed lines
+Set `strokeDasharray` property in series to change line style to dashed:
+
+
+.. exec::docs.compositechart.dashedlines
+
+
+### Reference lines
+
+Use `referenceLines` prop to render reference lines. Reference lines are always rendered behind the chart.
+
+.. exec::docs.compositechart.referencelines
+
+
+### clickData
+Use the `clickData` property in a callback to retrieve data from the most recent click event.
+To get the name of the clicked series, use the `clickSeriesName` property.
+
+.. exec::docs.compositechart.clickdata
+
+
+### hoverData
+Use the `hoverData` property in a callback to retrieve data from the most recent hover event.
+To get the name of the hovered series, use the `hoverSeriesName` property.
+
+.. exec::docs.compositechart.hoverdata
+
+
+### highlightHover
+
+Set `highlightHover=True` to highlight the series when hovered, mirroring the behavior of hovering over chart legend items.
+
+
+### Styles API
+
+This component supports [Styles API](/styles-api). With Styles API, you can customize styles of any inner element.
+For more information on styling components,  please also refer to the [Mantine Styles](https://mantine.dev/styles/styles-overview/) documentation.
+
+#### CompositeChart selectors 
+
+| Selector           | Static selector                           | Description                                   |
+|--------------------|-------------------------------------------|-----------------------------------------------|
+| root               | .mantine-CompositeChart-root              | Root element                                  |
+| area               | .mantine-CompositeChart-area              | Area of the chart                             |
+| line               | .mantine-CompositeChart-line              | Line of the chart                             |
+| bar                | .mantine-CompositeChart-bar               | Bar of the chart                              |
+| axis               | .mantine-CompositeChart-axis              | X and Y axis of the chart                     |
+| container          | .mantine-CompositeChart-container         | Recharts ResponsiveContainer component        |
+| grid               | .mantine-CompositeChart-grid              | Recharts CartesianGrid component              |
+| legend             | .mantine-CompositeChart-legend            | Legend root element                           |
+| legendItem         | .mantine-CompositeChart-legendItem        | Legend item representing data series          |
+| legendItemColor    | .mantine-CompositeChart-legendItemColor   | Legend item color                             |
+| legendItemName     | .mantine-CompositeChart-legendItemName    | Legend item name                              |
+| tooltip            | .mantine-CompositeChart-tooltip           | Tooltip root element                          |
+| tooltipBody        | .mantine-CompositeChart-tooltipBody       | Tooltip wrapper around all items              |
+| tooltipItem        | .mantine-CompositeChart-tooltipItem       | Tooltip item representing data series         |
+| tooltipItemBody    | .mantine-CompositeChart-tooltipItemBody   | Tooltip item wrapper around item color and name |
+| tooltipItemColor   | .mantine-CompositeChart-tooltipItemColor  | Tooltip item color                            |
+| tooltipItemName    | .mantine-CompositeChart-tooltipItemName   | Tooltip item name                             |
+| tooltipItemData    | .mantine-CompositeChart-tooltipItemData   | Tooltip item data                             |
+| tooltipLabel       | .mantine-CompositeChart-tooltipLabel      | Label of the tooltip                          |
+| referenceLine      | .mantine-CompositeChart-referenceLine     | Reference line                                |
+| axisLabel          | .mantine-CompositeChart-axisLabel         | X and Y axis labels                           |
+
+
+### Composite CSS variables
+
+| Selector         | Variable             | Description                                      |
+|:-----------------|:---------------------|:-------------------------------------------------|
+| root             | --chart-grid-color   | Controls color of the grid and cursor lines      |
+|                  | --chart-text-color   | Controls color of the axis labels                |
+
+
+
+### Keyword Arguments
+
+#### CompositeChart
+
+.. kwargs::CompositeChart

--- a/docs/compositechart/customizedots.py
+++ b/docs/compositechart/customizedots.py
@@ -1,0 +1,16 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    dotProps={"r": 6, "strokeWidth": 2, "stroke": "#fff"},
+    activeDotProps={"r": 8, "strokeWidth": 1, "fill": "#fff"},
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)

--- a/docs/compositechart/dashedlines.py
+++ b/docs/compositechart/dashedlines.py
@@ -1,0 +1,17 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    strokeWidth=1,
+    dotProps={"r": 2},
+    activeDotProps={"r": 3, "strokeWidth": 1},
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line", "strokeDasharray": "5 5"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area", "strokeDasharray": "5 5"},
+    ]
+)

--- a/docs/compositechart/data.py
+++ b/docs/compositechart/data.py
@@ -1,0 +1,32 @@
+data = [
+    {
+        "date": "Mar 22",
+        "Apples": 2890,
+        "Oranges": 2338,
+        "Tomatoes": 2452,
+    },
+    {
+        "date": "Mar 23",
+        "Apples": 2756,
+        "Oranges": 2103,
+        "Tomatoes": 2402,
+    },
+    {
+        "date": "Mar 24",
+        "Apples": 3322,
+        "Oranges": 986,
+        "Tomatoes": 1821,
+    },
+    {
+        "date": "Mar 25",
+        "Apples": 3470,
+        "Oranges": 2108,
+        "Tomatoes": 2809,
+    },
+    {
+        "date": "Mar 26",
+        "Apples": 3129,
+        "Oranges": 1726,
+        "Tomatoes": 2290,
+    },
+]

--- a/docs/compositechart/highlighthover.py
+++ b/docs/compositechart/highlighthover.py
@@ -1,0 +1,17 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    withLegend=True,
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ],
+    withTooltip=False,
+    highlightHover=True
+)

--- a/docs/compositechart/hoverdata.py
+++ b/docs/compositechart/hoverdata.py
@@ -1,0 +1,33 @@
+from dash import callback, Input, Output
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.Group(
+    [
+        dmc.CompositeChart(
+            id="figure-compositechart-hover",
+            h=300,
+            data=data,
+            dataKey="date",
+            withLegend=True,
+            maxBarWidth=30,
+            series=[
+                {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+                {"name": "Apples", "color": "red.8", "type": "line"},
+                {"name": "Oranges", "color": "yellow.8", "type": "area"},
+            ]
+        ),
+        dmc.Text(id="hoverdata-compositechart1"),
+        dmc.Text(id="hoverdata-compositechart2"),
+    ]
+)
+
+@callback(
+    Output("hoverdata-compositechart1", "children"),
+    Output("hoverdata-compositechart2", "children"),
+    Input("figure-compositechart-hover", "hoverData"),
+    Input("figure-compositechart-hover", "hoverSeriesName"),
+)
+def update(data, name):
+    return f"hoverData:  {data}", f"hoverSeriesName: {name}"
+

--- a/docs/compositechart/interactive.py
+++ b/docs/compositechart/interactive.py
@@ -1,0 +1,34 @@
+import dash_mantine_components as dmc
+from .data import data
+
+from lib.configurator import Configurator
+
+target =dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    withLegend=True,
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)
+
+configurator = Configurator(target)
+
+
+configurator.add_select(
+    "curveType",
+    ["Bump", "Linear", "Natural", "Monotone", "Step", "StepBefore", "StepAfter"],
+    "Linear",
+)
+
+configurator.add_segmented_control("tickLine", ["x", "y", "xy", "none"], "xy")
+configurator.add_segmented_control("gridAxis", ["x", "y", "xy", "none"], "x")
+configurator.add_switch("withXAxis", True)
+configurator.add_switch("withYAxis", True)
+
+
+component = configurator.panel

--- a/docs/compositechart/legend.py
+++ b/docs/compositechart/legend.py
@@ -1,0 +1,15 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    withLegend=True,
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)

--- a/docs/compositechart/legendposition.py
+++ b/docs/compositechart/legendposition.py
@@ -1,0 +1,16 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    withLegend=True,
+    maxBarWidth=30,
+    legendProps={"verticalAlign": "bottom", "height": 50},
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)

--- a/docs/compositechart/pointslabels.py
+++ b/docs/compositechart/pointslabels.py
@@ -1,0 +1,16 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    withPointLabels=True,
+    withLegend=True,
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)

--- a/docs/compositechart/referencelines.py
+++ b/docs/compositechart/referencelines.py
@@ -1,0 +1,18 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    yAxisProps={"domain": [0, 100]},
+    referenceLines=[
+        {"y": 1200, "label": "Average sales", "color": "red.6"},
+        {"x": "Mar 25", "label": "Report out", "color": "blue.7"},
+    ],
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+    ]
+)

--- a/docs/compositechart/removetooltip.py
+++ b/docs/compositechart/removetooltip.py
@@ -1,0 +1,15 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    withTooltip=False,
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)

--- a/docs/compositechart/serieslabels.py
+++ b/docs/compositechart/serieslabels.py
@@ -1,0 +1,31 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    withLegend=True,
+    legendProps={"verticalAlign": "bottom"},
+    maxBarWidth=30,
+    series=[
+        {
+            "name": "Tomatoes",
+            "label": "Tomatoes sales",
+            "color": "rgba(18, 120, 255, 0.2)",
+            "type": "bar",
+        },
+        {
+            "name": "Apples",
+            "label": "Apples sales",
+            "color": "red.8",
+            "type": "line",
+        },
+        {
+            "name": "Oranges",
+            "label": "Oranges sales",
+            "color": "yellow.8",
+            "type": "area",
+        },
+    ]
+)

--- a/docs/compositechart/strokedasharray.py
+++ b/docs/compositechart/strokedasharray.py
@@ -1,0 +1,15 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    strokeDasharray="15 15",
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)

--- a/docs/compositechart/strokewidth.py
+++ b/docs/compositechart/strokewidth.py
@@ -1,0 +1,22 @@
+import dash_mantine_components as dmc
+from .data import data
+from lib.configurator import Configurator
+
+target = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    strokeWidth=2,
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)
+
+configurator = Configurator(target)
+
+configurator.add_number_slider("strokeWidth", 2, min=0.5, max=5)
+
+component = configurator.panel

--- a/docs/compositechart/sync.py
+++ b/docs/compositechart/sync.py
@@ -1,0 +1,24 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.Stack(
+    [
+
+        dmc.Text("Apples sales:", mb="md", pl="md"),
+        dmc.CompositeChart(
+            h=180,
+            data=data,
+            dataKey="date",
+            series=[{"name": "Apples", "color": "indigo.6", "type": "area"}],
+            composedChartProps={"syncId": "groceries"}
+        ),
+        dmc.Text("Tomatoes sales:", mb="md", pl="md", mt="xl"),
+        dmc.CompositeChart(
+            h=180,
+            data=data,
+            dataKey="date",
+            series=[{"name": "Tomatoes", "color": "cyan.6", "type": "bar"}],
+            composedChartProps={"syncId": "groceries"}
+        )
+    ]
+)

--- a/docs/compositechart/tooltipanimation.py
+++ b/docs/compositechart/tooltipanimation.py
@@ -1,0 +1,15 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    tooltipAnimationDuration=200,
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)

--- a/docs/compositechart/units.py
+++ b/docs/compositechart/units.py
@@ -1,0 +1,15 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    unit="$",
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)

--- a/docs/compositechart/xaxisoffset.py
+++ b/docs/compositechart/xaxisoffset.py
@@ -1,0 +1,28 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.BarChart(
+    h=300,
+    dataKey="month",
+    data=data,
+    type="stacked",
+    xAxisProps={"padding": {"left": 30, "right": 30}},
+    series=[
+        {"name": "Smartphones", "color": "violet.6"},
+        {"name": "Laptops", "color": "blue.6"},
+        {"name": "Tablets", "color": "teal.6"},
+    ],
+)
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    xAxisProps={"padding": {"left": 30, "right": 30}},
+    maxBarWidth=30,
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)

--- a/docs/compositechart/xyaxis.py
+++ b/docs/compositechart/xyaxis.py
@@ -1,0 +1,16 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    tickLine="xy",
+    yAxisProps={"tickMargin": 15, "orientation": "right"},
+    xAxisProps={"tickMargin": 15, "orientation": "top"},
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)

--- a/docs/compositechart/yaxisscale.py
+++ b/docs/compositechart/yaxisscale.py
@@ -1,0 +1,24 @@
+import dash_mantine_components as dmc
+
+data = [
+    {"date": "Mar 22", "Apples": 50},
+    {"date": "Mar 23", "Apples": 60},
+    {"date": "Mar 24", "Apples": 40},
+    {"date": "Mar 25", "Apples": 30},
+    {"date": "Mar 26", "Apples": 0},
+    {"date": "Mar 27", "Apples": 20},
+    {"date": "Mar 28", "Apples": 20},
+    {"date": "Mar 29", "Apples": 10},
+]
+
+component = dmc.CompositeChart(
+    h=300,
+    data=data,
+    dataKey="date",
+    yAxisProps={"domain": [0, 100]},
+    withLegend=True,
+    maxBarWidth=30,
+    series=[
+        {"name": "Apples", "color": "red.8", "type": "line"},
+    ]
+)

--- a/docs/donutchart/clickdata.py
+++ b/docs/donutchart/clickdata.py
@@ -2,17 +2,21 @@ from dash import callback, Input, Output
 import dash_mantine_components as dmc
 from .data import data
 
-component = dmc.Group(
+component = dmc.Stack(
     [
         dmc.DonutChart(id="figure-donutchart", data=data, withTooltip=False),
-        dmc.Text(id="clickdata-donutchart"),
+        dmc.Text(id="clickdata-donutchart1"),
+        dmc.Text(id="clickdata-donutchart2"),
     ]
 )
 
 
+
 @callback(
-    Output("clickdata-donutchart", "children"),
+    Output("clickdata-donutchart1", "children"),
+    Output("clickdata-donutchart2", "children"),
     Input("figure-donutchart", "clickData"),
+    Input("figure-donutchart", "clickSeriesName"),
 )
-def update(clickdata):
-    return str(clickdata)
+def update(data, name):
+    return f"clickData:  {data}", f"clickSeriesName: {name}"

--- a/docs/donutchart/donut.md
+++ b/docs/donutchart/donut.md
@@ -180,10 +180,19 @@ By default, the Recharts data animation is disabled. To enable and customize the
 
 .. exec::docs.donutchart.donut_animation
 
-### clickData
-You can use the  `clickData` property in a callback to get data from latest click event.
 
+### clickData
+Use the `clickData` property in a callback to retrieve data from the most recent click event. To get the name of the
+clicked series, use the `clickSeriesName` property.
 .. exec::docs.donutchart.clickdata
+
+
+
+### hoverData
+Use the `hoverData` property in a callback to retrieve data from the most recent hover event. To get the name of the 
+hovered series, use the `hoverSeriesName` property.
+
+.. exec::docs.donutchart.hoverdata
 
 
 ### Styles API

--- a/docs/donutchart/hoverdata.py
+++ b/docs/donutchart/hoverdata.py
@@ -1,0 +1,21 @@
+from dash import callback, Input, Output
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.Stack(
+    [
+        dmc.DonutChart(id="figure-donutchart-hover", data=data, withTooltip=False),
+        dmc.Text(id="hoverdata-donutchart1"),
+        dmc.Text(id="hoverdata-donutchart2"),
+    ]
+)
+
+
+@callback(
+    Output("hoverdata-donutchart1", "children"),
+    Output("hoverdata-donutchart2", "children"),
+    Input("figure-donutchart-hover", "hoverData"),
+    Input("figure-donutchart-hover", "hoverSeriesName"),
+)
+def update(data, name):
+    return f"hoverData:  {data}", f"hoverSeriesName: {name}"

--- a/docs/linechart/clickdata.py
+++ b/docs/linechart/clickdata.py
@@ -15,7 +15,8 @@ component = dmc.Group(
                 {"name": "Oranges", "color": "blue.6"},
                 {"name": "Tomatoes", "color": "teal.6"},
             ],
-            withTooltip=False,
+            activeDotProps={"r": 8, "strokeWidth": 1, "fill": "#fff"},
+            strokeWidth=4
         ),
         dmc.Text(id="clickdata-linechart1"),
         dmc.Text(id="clickdata-linechart2"),

--- a/docs/linechart/highlighthover.py
+++ b/docs/linechart/highlighthover.py
@@ -1,0 +1,16 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.LineChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    series=[
+        {"name": "Apples", "color": "indigo.6"},
+        {"name": "Oranges", "color": "blue.6"},
+        {"name": "Tomatoes", "color": "teal.6"},
+    ],
+    withLegend=True,
+    highlightHover=True,
+    withTooltip=False
+)

--- a/docs/linechart/highlighthover.py
+++ b/docs/linechart/highlighthover.py
@@ -12,5 +12,6 @@ component = dmc.LineChart(
     ],
     withLegend=True,
     highlightHover=True,
-    withTooltip=False
+    withTooltip=False,
+    strokeWidth=4
 )

--- a/docs/linechart/hoverdata.py
+++ b/docs/linechart/hoverdata.py
@@ -17,7 +17,8 @@ component = dmc.Group(
                 {"name": "Oranges", "color": "blue.6"},
                 {"name": "Tomatoes", "color": "teal.6"},
             ],
-            withTooltip=False,
+            activeDotProps={"r": 8, "strokeWidth": 1, "fill": "#fff"},
+            strokeWidth=4
         ),
         dmc.Text(id="hoverdata-linechart1"),
         dmc.Text(id="hoverdata-linechart2"),

--- a/docs/linechart/hoverdata.py
+++ b/docs/linechart/hoverdata.py
@@ -2,14 +2,16 @@ from dash import callback, Input, Output
 import dash_mantine_components as dmc
 from .data import data
 
+import dash_mantine_components as dmc
+from .data import data
+
 component = dmc.Group(
     [
         dmc.LineChart(
-            id="figure-linechart",
+            id="figure-linechart-hover",
             h=300,
             dataKey="date",
             data=data,
-            withLegend=True,
             series=[
                 {"name": "Apples", "color": "indigo.6"},
                 {"name": "Oranges", "color": "blue.6"},
@@ -17,19 +19,18 @@ component = dmc.Group(
             ],
             withTooltip=False,
         ),
-        dmc.Text(id="clickdata-linechart1"),
-        dmc.Text(id="clickdata-linechart2"),
+        dmc.Text(id="hoverdata-linechart1"),
+        dmc.Text(id="hoverdata-linechart2"),
     ]
 )
 
 
-
 @callback(
-    Output("clickdata-linechart1", "children"),
-    Output("clickdata-linechart2", "children"),
-    Input("figure-linechart", "clickData"),
-    Input("figure-linechart", "clickSeriesName"),
+    Output("hoverdata-linechart1", "children"),
+    Output("hoverdata-linechart2", "children"),
+    Input("figure-linechart-hover", "hoverData"),
+    Input("figure-linechart-hover", "hoverSeriesName"),
 )
 def update(data, name):
-    return f"clickData:  {data}", f"clickSeriesName: {name}"
+    return f"hoverData:  {data}", f"hoverSeriesName: {name}"
 

--- a/docs/linechart/line.md
+++ b/docs/linechart/line.md
@@ -228,9 +228,23 @@ Use `referenceLines` prop to render reference lines. Reference lines are always 
 
 
 ### clickData
-You can use the  `clickData` property in a callback to get data from latest click event.
+Use the `clickData` property in a callback to retrieve data from the most recent click event.
+To get the name of the clicked series, use the `clickSeriesName` property.
 
 .. exec::docs.linechart.clickdata
+
+
+### hoverData
+Use the `hoverData` property in a callback to retrieve data from the most recent hover event.
+To get the name of the hovered series, use the `hoverSeriesName` property.
+
+.. exec::docs.linechart.hoverdata
+
+### highlightHover
+
+Set `highlightHover=True` to highlight the series when hovered, mirroring the behavior of hovering over chart legend items.
+
+.. exec::docs.linechart.highlighthover
 
 
 ### Styles API

--- a/docs/linechart/line.md
+++ b/docs/linechart/line.md
@@ -231,12 +231,16 @@ Use `referenceLines` prop to render reference lines. Reference lines are always 
 Use the `clickData` property in a callback to retrieve data from the most recent click event.
 To get the name of the clicked series, use the `clickSeriesName` property.
 
+Note: To enable `clickSeriesName` when clicking on the dots,  set `withTooltip=True`.
+
 .. exec::docs.linechart.clickdata
 
 
 ### hoverData
 Use the `hoverData` property in a callback to retrieve data from the most recent hover event.
 To get the name of the hovered series, use the `hoverSeriesName` property.
+
+Note: To enable `hoverSeriesName` when hovering on the dots,  set `withTooltip=True`.
 
 .. exec::docs.linechart.hoverdata
 

--- a/docs/piechart/clickdata.py
+++ b/docs/piechart/clickdata.py
@@ -7,7 +7,6 @@ component = dmc.Stack(
         dmc.PieChart(
             id="figure-piechart",
             data=data,
-           # withTootlip=False
         ),
         dmc.Text(id="clickdata-piechart1"),
         dmc.Text(id="clickdata-piechart2"),

--- a/docs/piechart/clickdata.py
+++ b/docs/piechart/clickdata.py
@@ -2,20 +2,24 @@ from dash import callback, Input, Output
 import dash_mantine_components as dmc
 from .data import data
 
-component = dmc.Group(
+component = dmc.Stack(
     [
         dmc.PieChart(
             id="figure-piechart",
             data=data,
+           # withTootlip=False
         ),
-        dmc.Text(id="clickdata-piechart"),
+        dmc.Text(id="clickdata-piechart1"),
+        dmc.Text(id="clickdata-piechart2"),
     ]
 )
 
 
 @callback(
-    Output("clickdata-piechart", "children"),
+    Output("clickdata-piechart1", "children"),
+    Output("clickdata-piechart2", "children"),
     Input("figure-piechart", "clickData"),
+    Input("figure-piechart", "clickSeriesName"),
 )
-def update(clickdata):
-    return str(clickdata)
+def update(data, name):
+    return f"clickData:  {data}", f"clickSeriesName: {name}"

--- a/docs/piechart/hoverdata.py
+++ b/docs/piechart/hoverdata.py
@@ -7,7 +7,6 @@ component = dmc.Stack(
         dmc.PieChart(
             id="figure-piechart-hover",
             data=data,
-        #    withTooltip=False,
         ),
         dmc.Text(id="hoverdata-piechart1"),
         dmc.Text(id="hoverdata-piechart2"),

--- a/docs/piechart/hoverdata.py
+++ b/docs/piechart/hoverdata.py
@@ -1,0 +1,25 @@
+from dash import callback, Input, Output
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.Stack(
+    [
+        dmc.PieChart(
+            id="figure-piechart-hover",
+            data=data,
+        #    withTooltip=False,
+        ),
+        dmc.Text(id="hoverdata-piechart1"),
+        dmc.Text(id="hoverdata-piechart2"),
+    ]
+)
+
+
+@callback(
+    Output("hoverdata-piechart1", "children"),
+    Output("hoverdata-piechart2", "children"),
+    Input("figure-piechart-hover", "hoverData"),
+    Input("figure-piechart-hover", "hoverSeriesName"),
+)
+def update(data, name):
+    return f"hoverData:  {data}", f"hoverSeriesName: {name}"

--- a/docs/piechart/pie.md
+++ b/docs/piechart/pie.md
@@ -157,10 +157,17 @@ By default, the Recharts data animation is disabled. To enable and customize the
 
 
 ### clickData
-You can use the  `clickData` property in a callback to get data from latest click event.
-
+Use the `clickData` property in a callback to retrieve data from the most recent click event. To get the name of the
+clicked series, use the `clickSeriesName` property.
 .. exec::docs.piechart.clickdata
 
+
+
+### hoverData
+Use the `hoverData` property in a callback to retrieve data from the most recent hover event. To get the name of the 
+hovered series, use the `hoverSeriesName` property.
+
+.. exec::docs.piechart.hoverdata
 
 ### Styles API
 

--- a/docs/scatterchart/clickdata.py
+++ b/docs/scatterchart/clickdata.py
@@ -1,25 +1,29 @@
 from dash import callback, Input, Output
 import dash_mantine_components as dmc
-from .data import data1
+from .data import data2
 
 component = dmc.Group(
     [
         dmc.ScatterChart(
             id="figure-scatterchart",
             h=300,
-            data=data1,
+            data=data2,
             dataKey={"x": "age", "y": "BMI"},
             xAxisLabel="Age",
             yAxisLabel="BMI",
         ),
-        dmc.Text(id="clickdata-scatterchart"),
+        dmc.Text(id="clickdata-scatterchart1"),
+        dmc.Text(id="clickdata-scatterchart2"),
     ]
 )
 
-
 @callback(
-    Output("clickdata-scatterchart", "children"),
+    Output("clickdata-scatterchart1", "children"),
+    Output("clickdata-scatterchart2", "children"),
     Input("figure-scatterchart", "clickData"),
+    Input("figure-scatterchart", "clickSeriesName"),
 )
-def update(clickdata):
-    return str(clickdata)
+def update(data, name):
+    return f"clickData:  {data}", f"clickSeriesName: {name}"
+
+

--- a/docs/scatterchart/hoverdata.py
+++ b/docs/scatterchart/hoverdata.py
@@ -1,0 +1,30 @@
+from dash import callback, Input, Output
+import dash_mantine_components as dmc
+from .data import data2
+
+component = dmc.Group(
+    [
+        dmc.ScatterChart(
+            id="figure-scatterchart-hover",
+            h=300,
+            data=data2,
+            dataKey={"x": "age", "y": "BMI"},
+            xAxisLabel="Age",
+            yAxisLabel="BMI",
+            withTooltip=False,
+        ),
+        dmc.Text(id="hoverdata-scatterchart1"),
+        dmc.Text(id="hoverdata-scatterchart2"),
+    ]
+)
+
+@callback(
+    Output("hoverdata-scatterchart1", "children"),
+    Output("hoverdata-scatterchart2", "children"),
+    Input("figure-scatterchart-hover", "hoverData"),
+    Input("figure-scatterchart-hover", "hoverSeriesName"),
+)
+def update(data, name):
+    return f"hoverData:  {data}", f"hoverSeriesName: {name}"
+
+

--- a/docs/scatterchart/scatter.md
+++ b/docs/scatterchart/scatter.md
@@ -218,10 +218,17 @@ Use `referenceLines` prop to render reference lines. Reference lines are always 
 
 
 ### clickData
-You can use the  `clickData` property in a callback to get data from latest click event.
-
+Use the `clickData` property in a callback to retrieve data from the most recent click event. To get the name of the
+clicked series, use the `clickSeriesName` property.
 .. exec::docs.scatterchart.clickdata
 
+
+
+### hoverData
+Use the `hoverData` property in a callback to retrieve data from the most recent hover event. To get the name of the 
+hovered series, use the `hoverSeriesName` property.
+
+.. exec::docs.scatterchart.hoverdata
 
 
 ### Styles API


### PR DESCRIPTION
Document new features in [DMC PR#368](https://github.com/snehilvj/dash-mantine-components/pull/368) 

**Do not merge until dmc 0.14.7 is released**


added `hoverData`, `hoverSeriesName`, `clickSeriesName` and `highlightHover` examples:
- [x] AreaChart
- [x] LineChart
- [x] BarChart
- [x]  CompositeChart 

add `hoverData, hoverSeriesName, clickSeriesName `
- [x] PieChart
- [x] DonutChart
- [x] ScatterChart

new sections:
- [x] Add CompositeChart Section
- [x] Add BubbleChart Section including `clickData` and `hoverData`