### PR TITLE
Added autoscroll option section to Carousel docs

### DIFF
--- a/docs/carousel/autoscroll.py
+++ b/docs/carousel/autoscroll.py
@@ -1,0 +1,12 @@
+import dash_mantine_components as dmc
+
+component = dmc.Carousel(
+    [
+        dmc.CarouselSlide(dmc.Center("Slide-1", bg="blue", c="white", p=60)),
+        dmc.CarouselSlide(dmc.Center("Slide-2", bg="blue", c="white", p=60)),
+        dmc.CarouselSlide(dmc.Center("Slide-3", bg="blue", c="white", p=60)),
+    ],
+    id="carousel-autoscroll",
+    loop=True,
+    autoScroll=True,
+)

--- a/docs/carousel/carousel.md
+++ b/docs/carousel/carousel.md
@@ -86,6 +86,11 @@ autoplay={"delay": 2000, "stopOnMouseEnter": True, "stopOnInteraction":False}
 ```
 .. exec::docs.carousel.autoplay_props
 
+### Autoscroll
+Enable autoscroll by setting `autoScroll=True` or by passing in a `dict` with options. Refer to [Embla Carousel Auto Scroll Options](https://www.embla-carousel.com/plugins/auto-scroll/#options) to learn more.
+
+.. exec::docs.carousel.autoscroll
+
 ### Carousel Styles API
 
 Carousel supports Styles API, you can add styles to any inner element of the component with `classNames` prop. Refer to the  [Styles API documentation](/styles-api) to learn more.


### PR DESCRIPTION
These are the docs for the new `autoScroll` option for the Carousel component [[PR#373](https://github.com/snehilvj/dash-mantine-components/pull/373)].