### PR TITLE
update checkbox

### DIFF
--- a/docs/areachart/areachart.md
+++ b/docs/areachart/areachart.md
@@ -327,9 +327,6 @@ Set `highlightHover=True` to highlight the series when hovered, mirroring the be
 
 ### Styles API
 
-
-.. exec::docs.areachart.highlighthover
-
 This component supports [Styles API](/styles-api). With Styles API, you can customize styles of any inner element.
 For more information on styling components,  please also refer to the [Mantine Styles](https://mantine.dev/styles/styles-overview/) documentation.
 

--- a/docs/checkbox/checkbox.md
+++ b/docs/checkbox/checkbox.md
@@ -19,11 +19,17 @@ Use the property `checked` in the callbacks.
 
 .. exec::docs.checkbox.simple
 
-### Different Sizes
+### States
 
-Choose from one of the following sizes: xs, sm, md, lg, xl.
+.. exec::docs.checkbox.states
 
-.. exec::docs.checkbox.sizes
+### Change icon color
+
+Use `iconColor` prop to change icon color. You can reference colors from theme.colors or use any valid CSS color:
+
+.. exec::docs.checkbox.iconcolor
+
+
 
 ### Different Colors
 
@@ -31,9 +37,56 @@ Set checkbox color using the `color` prop.
 
 .. exec::docs.checkbox.colors
 
+### Different Sizes
+
+Choose from one of the following sizes: xs, sm, md, lg, xl.
+
+.. exec::docs.checkbox.sizes
+
+### Indeterminate state
+`Checkbox` supports indeterminate state. When `indeterminate=True` prop is set, `checked` prop is ignored (checkbox
+always has checked styles)
+
+.. exec::docs.checkbox.indeterminate
+
+
 ### Label with link
 
 .. exec::docs.checkbox.link
+
+
+### Pointer cursor
+By default, checkbox input and label have `cursor: default` (same as native `input[type="checkbox"]`). To change cursor
+to pointer, set `cursorType` on `theme`:
+
+```python
+
+app.layout = dmc.MantineProvider(
+    theme = {"cursorType": "pointer"},
+    children={...}
+)
+```
+
+### Add props to the root element
+All props passed to the component are forwarded to the input element. If you need to add props to the root element,
+use `wrapperProps`. In the following example:
+
+- `data-testid="wrapper"` is added to the root element
+- `data-testid="input"` is added to the input element
+
+```python
+dmc.Checkboc(
+    wrapperProps={}
+)
+
+```
+import { Checkbox } from '@mantine/core';
+
+function Demo() {
+  return <Checkbox wrapperProps={{ 'data-testid': 'wrapper' }} data-testid="input" />;
+}
+
+For more information see the [MantineProvider](/components/mantineprovider) section.
 
 ### Checkbox Group
 
@@ -44,19 +97,53 @@ Use `value` property of the checkbox group in the callbacks.
 
 .. exec::docs.checkbox.group
 
+
 ### Styles API
 
-| Name         | Static selector                | Description                                   |
-|:-------------|:-------------------------------|:----------------------------------------------|
-| root         | .mantine-Checkbox-root         | Root element                                  |
-| body         | .mantine-Checkbox-body         | Input body, contains all other elements       |
-| inner        | .mantine-Checkbox-inner        | Wrapper for `icon` and `input`                |
-| labelWrapper | .mantine-Checkbox-labelWrapper | Contains `label`, `description` and `error`   |
-| input        | .mantine-Checkbox-input        | Input element                                 |
-| icon         | .mantine-Checkbox-icon         | Checkbox icon, used to display checkmark icon |
-| error        | .mantine-Checkbox-error        | Error message displayed below the label       |
-| description  | .mantine-Checkbox-description  | Description displayed below the label         |
-| label        | .mantine-Checkbox-label        | Label element                                 |
+This component supports [Styles API](/styles-api). With Styles API, you can customize styles of any inner element.
+For more information on styling components,  please also refer to the [Mantine Styles](https://mantine.dev/styles/styles-overview/) documentation.
+
+#### Checkbox Selectors
+
+| Selector       | Static selector              | Description                                             |
+|----------------|--------------------------------|---------------------------------------------------------|
+| root           | .mantine-Checkbox-root         | Root element                                            |
+| input          | .mantine-Checkbox-input        | Input element (input[type="checkbox"])                  |
+| icon           | .mantine-Checkbox-icon         | Checkbox icon, used to display checkmark and indeterminate state icon |
+| inner          | .mantine-Checkbox-inner        | Wrapper for icon and input                              |
+| body           | .mantine-Checkbox-body         | Input body, contains all other elements                 |
+| labelWrapper   | .mantine-Checkbox-labelWrapper | Contains label, description, and error                  |
+| label          | .mantine-Checkbox-label        | Label element                                           |
+| description    | .mantine-Checkbox-description  | Description displayed below the label                   |
+| error          | .mantine-Checkbox-error        | Error message displayed below the label                 |
+
+#### Checkbox CSS Variables
+
+| Selector | Variable            | Description                                     |
+|----------|----------------------|-------------------------------------------------|
+| root     | --checkbox-color     | Controls checked checkbox background-color     |
+|          | --checkbox-radius    | Controls checkbox border-radius                |
+|          | --checkbox-size      | Controls checkbox width and height             |
+|          | --checkbox-icon-color| Controls checkbox icon color                   |
+
+#### Checkbox Data Attributes
+
+| Selector | Attribute            | Condition                  | Value                             |
+|----------|-----------------------|-----------------------------|-----------------------------------|
+| root     | data-checked          | `checked` prop is set       | –                                 |
+| input    | data-error            | `error` prop is set         | –                                 |
+| input    | data-indeterminate    | `indeterminate` prop is set | –                                 |
+| inner    | data-label-position   | –                           | Value of `labelPosition` prop     |
+
+#### Checkbox.Group Selectors
+
+| Selector    | Static selector                   | Description                        |
+|-------------|------------------------------------|------------------------------------|
+| root        | .mantine-CheckboxGroup-root        | Root element                       |
+| label       | .mantine-CheckboxGroup-label       | Label element                      |
+| required    | .mantine-CheckboxGroup-required    | Required asterisk element, rendered inside label |
+| description | .mantine-CheckboxGroup-description | Description element                |
+| error       | .mantine-CheckboxGroup-error       | Error element                      |
 
 ### Keyword Arguments
 

--- a/docs/checkbox/group.py
+++ b/docs/checkbox/group.py
@@ -5,20 +5,20 @@ component = html.Div(
     [
         dmc.CheckboxGroup(
             id="checkbox-group",
-            label="Select your favorite framework/library",
+            label="Select your favorite library",
             description="This is anonymous",
             withAsterisk=True,
             mb=10,
             children=dmc.Group(
                 [
-                    dmc.Checkbox(label="React", value="react"),
-                    dmc.Checkbox(label="Vue", value="vue"),
-                    dmc.Checkbox(label="Svelte", value="svelte"),
-                    dmc.Checkbox(label="Angular", value="angular"),
+                    dmc.Checkbox(label="Pandas", value="pandas"),
+                    dmc.Checkbox(label="Polars", value="polars"),
+                    dmc.Checkbox(label="Vaex", value="vaex"),
+                    dmc.Checkbox(label="Dask", value="dask"),
                 ],
                 mt=10,
             ),
-            value=["react", "vue"],
+            value=["pandas", "polars"],
         ),
         dmc.Text(id="checkbox-group-output"),
     ]

--- a/docs/checkbox/iconcolor.py
+++ b/docs/checkbox/iconcolor.py
@@ -1,0 +1,9 @@
+import dash_mantine_components as dmc
+
+component = dmc.Checkbox(
+    checked=True,
+    color="lime.4",
+    iconColor="dark.8",
+    size="md",
+    label="Bright lime checkbox"
+)

--- a/docs/checkbox/icons.py
+++ b/docs/checkbox/icons.py
@@ -1,0 +1,19 @@
+import dash_mantine_components as dmc
+from dash_iconify import DashIconify
+
+
+component = dmc.Stack([
+    dmc.Checkbox(
+        label="Custom checked icon",
+        checked=True,
+        icon=DashIconify(icon="ion:bag-check-sharp"),
+        size="lg",
+        p=0,
+    ),
+    dmc.Checkbox(
+        label="Custom intermediate icons",
+        indeterminate=True,
+        indeterminateIcon=DashIconify(icon="material-symbols:indeterminate-question-box"),
+        size="lg"
+    )
+])

--- a/docs/checkbox/indeterminate.py
+++ b/docs/checkbox/indeterminate.py
@@ -1,0 +1,39 @@
+
+
+from dash import  html,  Input, Output,  callback, ALL
+import dash_mantine_components as dmc
+
+initial_values = [
+    {"label": "Receive email notifications", "checked": False},
+    {"label": "Receive sms notifications", "checked": False},
+    {"label": "Receive push notifications", "checked": False},
+]
+
+component = html.Div([
+    dmc.Checkbox(
+        id="all-notifications",
+        label="Receive all notifications",
+        checked=False,
+        indeterminate=False
+    ),
+    html.Div([
+        dmc.Checkbox(
+            id={"type": "notification-item", "index": i},
+            label=item["label"],
+            checked=item["checked"],
+            style={"marginTop": "5px", "marginLeft": "33px"}
+        )
+        for i, item in enumerate(initial_values)
+    ])
+])
+
+
+@callback(
+    Output("all-notifications", "checked"),
+    Output("all-notifications", "indeterminate"),
+    Input({"type": "notification-item", "index": ALL}, "checked")
+)
+def update_main_checkbox(checked_states):
+    all_checked = all(checked_states)
+    indeterminate = any(checked_states) and not all_checked
+    return all_checked, indeterminate

--- a/docs/checkbox/interactive.py
+++ b/docs/checkbox/interactive.py
@@ -11,8 +11,14 @@ target = dmc.Center(
 configurator = Configurator(target, TARGET_ID)
 
 configurator.add_segmented_control("labelPosition", ["left", "right"], "right")
+configurator.add_text_input("label", "I agree to sell my privacy")
+configurator.add_text_input("description", "")
+configurator.add_text_input("error", "")
 configurator.add_colorpicker("color", "indigo")
+configurator.add_segmented_control("variant", ["filled", "outline"], "filled")
 configurator.add_slider("size", "sm")
 configurator.add_slider("radius", "sm")
+configurator.add_switch("disabled", False)
+configurator.add_switch("indeterminate", False)
 
 component = configurator.panel

--- a/docs/checkbox/states.py
+++ b/docs/checkbox/states.py
@@ -1,0 +1,12 @@
+import dash_mantine_components as dmc
+
+component = dmc.Stack([
+    dmc.Checkbox(checked=False, label="Default checkbox"),
+    dmc.Checkbox(checked=False, indeterminate=True, label="Indeterminate checkbox"),
+    dmc.Checkbox(checked=True, label="Checked checkbox"),
+    dmc.Checkbox(checked=True, variant="outline", label="Outline checked checkbox"),
+    dmc.Checkbox(variant="outline", indeterminate=True, label="Outline indeterminate checkbox"),
+    dmc.Checkbox(disabled=True, label="Disabled checkbox"),
+    dmc.Checkbox(disabled=True, checked=True, label="Disabled checked checkbox"),
+    dmc.Checkbox(disabled=True, indeterminate=True, label="Disabled indeterminate checkbox")
+])

--- a/docs/chip/chip.md
+++ b/docs/chip/chip.md
@@ -63,6 +63,10 @@ To enable deselecting a radio chip, set `deselectable=True`
 
 ### Styles API
 
+This component supports [Styles API](/styles-api). With Styles API, you can customize styles of any inner element.
+For more information on styling components,  please also refer to the [Mantine Styles](https://mantine.dev/styles/styles-overview/) documentation.
+
+
 
 #### Chip Selectors
 


### PR DESCRIPTION
Updated checkbox section to include examples of:
- icon color
- indeterminate
- states

General cleanup and expanded styles api section

added icon example for when 0.14.8 is released