### PR TITLE
segmented control disabled section

### DIFF
--- a/docs/segmentedcontrol/disabled.py
+++ b/docs/segmentedcontrol/disabled.py
@@ -1,0 +1,24 @@
+import dash_mantine_components as dmc
+
+component = dmc.Stack(
+    [
+        dmc.Text("Disabled control"),
+        dmc.SegmentedControl(
+            disabled=True,
+            data=[
+                {"value": "preview", "label": "Preview"},
+                {"value": "code", "label": "Code"},
+                {"value": "export", "label": "Export"},
+            ],
+        ),
+        dmc.Text("Disabled option"),
+        dmc.SegmentedControl(
+            data=[
+                {"value": "preview", "label": "Preview", "disabled": True},
+                {"value": "code", "label": "Code"},
+                {"value": "export", "label": "Export"},
+            ],
+        ),
+    ],
+    align="flex-start",
+)

--- a/docs/segmentedcontrol/segmentedcontrol.md
+++ b/docs/segmentedcontrol/segmentedcontrol.md
@@ -19,7 +19,7 @@ limited to certain options)
 
 The data can be provided as either:
 * an array of strings - use when label and value are same.
-* an array of dicts with `label` and `value` properties.
+* an array of dicts with `label` and `value` properties (plus an optional `disabled` boolean).
 
 ```python
 data = ["React", "Angular", "Svelte", "Vue"]
@@ -29,7 +29,7 @@ data = ["React", "Angular", "Svelte", "Vue"]
 data = [
     {"value": "React", "label": "React"},
     {"value": "Angular", "label": "Angular"},
-    {"value": "Svelte", "label": "Svelte"},
+    {"value": "Svelte", "label": "Svelte", "disabled": True},
     {"value": "Vue", "label": "Vue"},
 ]
 ```

--- a/docs/segmentedcontrol/segmentedcontrol.md
+++ b/docs/segmentedcontrol/segmentedcontrol.md
@@ -34,6 +34,12 @@ data = [
 ]
 ```
 
+### Disabled
+
+To disable the entire component, use the `disabled` prop. To disable a SegmentedControl item, use the array of objects data format and set `disabled = True` on the item that you want to disable. 
+
+.. exec::docs.segmentedcontrol.disabled
+
 ### Full Width and Orientation
 
 By default, SegmentedControl will take only the amount of space that is required to render elements. Set `fullWidth` 


### PR DESCRIPTION
I have copied the mantine docs for `segmentedControl`. 

The whole component `disabled` feature is already implemented, but the ability to disable individual control segments is not yet merged, see https://github.com/snehilvj/dash-mantine-components/issues/450 .

Therefore this documentation shouldn't be merged until the above request is merged in dash-mantine-components.