### PR TITLE
Update4 for 0 15 1

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -203,3 +203,17 @@ input:invalid {
     background-color: var(--mantine-color-red-filled);
   }
 }
+
+
+.buttton-custom-variant {
+  &[data-variant='danger'] {
+    background-color: var(--mantine-color-red-9);
+    color: var(--mantine-color-red-0);
+  }
+
+  &[data-variant='primary'] {
+    background: linear-gradient(45deg, #4b6cb7 10%, #253b67 90%);
+    color: var(--mantine-color-white);
+    border-width: 0;
+  }
+}

--- a/docs/actionicon/actionicon.md
+++ b/docs/actionicon/actionicon.md
@@ -116,7 +116,6 @@ Example:
  - [Live Demo on PyCafe](https://py.cafe/dash.mantine.components/actionicon-custom-variants-demo)  
 
 
-
 The example includes the following in a .css file in /assets
 ```css
 .ai-custom-variants {

--- a/docs/button/button.md
+++ b/docs/button/button.md
@@ -154,9 +154,8 @@ the `theme` prop in the `MantineProvider` so they available in all `Button` comp
 
 Example:
  - [View Code on GitHub](https://github.com/snehilvj/dmc-docs/tree/main/help_center/theme/button_custom_variants.py)  
- - [Live Demo on PyCafe](https://py.cafe/dash.mantine.components/button-variants-demo-0)  
-
-
+ - [Live Demo on PyCafe](https://py.cafe/dash.mantine.components/button-custom-variants-demo-0)  
+ 
 
 The example includes the following in a .css file in /assets
 ```css

--- a/docs/button/button.md
+++ b/docs/button/button.md
@@ -145,6 +145,49 @@ Pass `fullWidth=True` for a full width button.
 
 .. exec::docs.button.full
 
+
+### Add custom variants
+
+To add new `Button` variants, define a class in the `.css` file using the `data-variant` attribute. Add the new variants to
+the `theme` prop in the `MantineProvider` so they available in all `Button` components in your app.
+
+
+Example:
+ - [View Code on GitHub](https://github.com/snehilvj/dmc-docs/tree/main/help_center/theme/button_custom_variants.py)  
+ - [Live Demo on PyCafe](https://py.cafe/dash.mantine.components/button-variants-demo-0)  
+
+
+
+The example includes the following in a .css file in /assets
+```css
+.button-custom-variants {
+  &[data-variant='danger'] {
+    background-color: var(--mantine-color-red-9);
+    color: var(--mantine-color-red-0);
+  }
+
+  &[data-variant='primary'] {
+    background: linear-gradient(45deg, #4b6cb7 10%, #253b67 90%);
+    color: var(--mantine-color-white);
+    border-width: 0;
+  }
+}
+```
+
+The example adds the custom variants to the `theme` prop in `Mantine Provider`
+
+```python
+app.layout = dmc.MantineProvider(
+   children=[# your app content],
+   theme={
+      "components": {
+           "Button": {"classNames": {"root": "button-custom-variants"}}
+       }
+   }
+)
+```
+
+
 ### Button Group
 
 .. exec::docs.button.group

--- a/docs/button/button.md
+++ b/docs/button/button.md
@@ -149,6 +149,15 @@ Pass `fullWidth=True` for a full width button.
 
 .. exec::docs.button.group
 
+Note that you must not wrap child `Button` components with any additional elements:
+
+```python
+dmc.ButtonGroup([
+    html.Div(dmc.Button("This will not work")),
+    dmc.Button("Buttons will have incorrect borders")
+])
+```
+
 ### Styles API
 
 #### Button Selectors

--- a/docs/theme-object/themeobject.md
+++ b/docs/theme-object/themeobject.md
@@ -251,6 +251,13 @@ dmc.MantineProvider(
 )
 ```
 
+#### components custom variants
+
+See how to add custom variants to `ActionIcon` and `Button` in the theme object, making these variants available globally
+across your app. Detailed examples are provided in their respective documentation sections.  Also, see examples live:
+
+- [Live Demo: Button Variants on PyCafe](https://py.cafe/dash.mantine.components/button-custom-variants-demo-0)  
+- [Live Demo: ActionIcon Variants on PyCafe](https://py.cafe/dash.mantine.components/actionicon-custom-variants-demo)  
 
 #### other 
 

--- a/help_center/aggrid/app_cell_renderer_button.py
+++ b/help_center/aggrid/app_cell_renderer_button.py
@@ -1,0 +1,154 @@
+"""
+styling with custom cell renderer
+
+Note:
+Custom components  must be defined in the dashAgGridComponentFunctions.js in assets folder.
+"""
+
+import json
+import dash_ag_grid as dag
+from dash import Dash, html, dcc, Input, Output, _dash_renderer
+import pandas as pd
+import dash_mantine_components as dmc
+import dash_iconify
+
+_dash_renderer._set_react_version("18.2.0")
+data = {
+    "ticker": ["AAPL", "MSFT", "AMZN", "GOOGL"],
+    "company": ["Apple", "Microsoft", "Amazon", "Alphabet"],
+    "price": [154.99, 268.65, 100.47, 96.75],
+    "buy": ["Buy" for _ in range(4)],
+    "sell": ["Sell" for _ in range(4)],
+    "watch": ["Watch" for _ in range(4)],
+}
+df = pd.DataFrame(data)
+
+columnDefs = [
+    {
+        "headerName": "Stock Ticker",
+        "field": "ticker",
+    },
+    {"headerName": "Company", "field": "company", "filter": True},
+    {
+        "headerName": "Last Close Price",
+        "type": "rightAligned",
+        "field": "price",
+        "valueFormatter": {"function": """d3.format("($,.2f")(params.value)"""},
+    },
+    {
+        "field": "buy",
+        "cellRenderer": "DMC_Button",
+        "cellRendererParams": {
+            "variant": "outline",
+            "leftIcon": "ic:baseline-shopping-cart",
+            "color": "green",
+            "radius": "xl"
+        },
+    },
+    {
+        "field": "sell",
+        "cellRenderer": "DMC_Button",
+        "cellRendererParams": {
+            "variant": "outline",
+            "leftIcon": "ic:baseline-shopping-cart",
+            "color": "red",
+            "radius": "xl"
+        },
+    },
+{
+        "field": "watch",
+        "cellRenderer": "DMC_Button",
+        "cellRendererParams": {
+            "rightIcon": "ph:eye",
+        },
+    },
+]
+
+
+defaultColDef = {
+    "resizable": True,
+    "sortable": True,
+    "editable": False,
+}
+
+
+grid = dag.AgGrid(
+    id="custom-component-dmc-btn-grid",
+    columnDefs=columnDefs,
+    rowData=df.to_dict("records"),
+    columnSize="autoSize",
+    defaultColDef=defaultColDef,
+)
+
+
+app = Dash(__name__)
+
+app.layout = dmc.MantineProvider(html.Div(
+    [
+        dcc.Markdown("Example of cellRenderer with dash-mantine-components Button  and DashIconify icons"),
+        grid,
+        html.Div(id="custom-component-dmc-btn-value-changed"),
+    ],
+    style={"margin": 20},
+), forceColorScheme="light")
+
+
+@app.callback(
+    Output("custom-component-dmc-btn-value-changed", "children"),
+    Input("custom-component-dmc-btn-grid", "cellRendererData"),
+)
+def showChange(n):
+    return json.dumps(n)
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True)
+
+
+"""
+Put the following in the dashAgGridComponentFunctions.js file in the assets folder
+
+---------------
+
+var dagcomponentfuncs = window.dashAgGridComponentFunctions = window.dashAgGridComponentFunctions || {};
+
+dagcomponentfuncs.DMC_Button = function (props) {
+    const {setData, data} = props;
+
+    function onClick() {
+        setData();
+    }
+    let leftIcon, rightIcon;
+    if (props.leftIcon) {
+        leftIcon = React.createElement(window.dash_iconify.DashIconify, {
+            icon: props.leftIcon,
+        });
+    }
+    if (props.rightIcon) {
+        rightIcon = React.createElement(window.dash_iconify.DashIconify, {
+            icon: props.rightIcon,
+        });
+    }
+    return React.createElement(
+        window.dash_mantine_components.Button,
+        {
+            onClick,
+            variant: props.variant,
+            color: props.color,
+            leftSection: leftIcon,
+            rightSection: rightIcon,        
+            radius: props.radius,
+            style: {
+                margin: props.margin,
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+            },
+        },
+        props.value
+    );
+};
+
+
+
+"""

--- a/help_center/aggrid/app_cell_renderer_cards.py
+++ b/help_center/aggrid/app_cell_renderer_cards.py
@@ -1,0 +1,97 @@
+"""
+styling with custom cell renderer - Cards
+
+Note:
+Custom components  must be defined in the dashAgGridComponentFunctions.js in assets folder.
+"""
+
+
+import dash_ag_grid as dag
+from dash import Dash, html, dcc, _dash_renderer
+import pandas as pd
+import dash_mantine_components as dmc
+
+_dash_renderer._set_react_version("18.2.0")
+data = {
+
+    "stats": ["Revenue", "EBITDA", "Net Income"],
+    "results": ['$13,120,000','$1,117,000', '$788,000'],
+    "change": [10.1, -22.1, 18.6],
+    'comments': ['', '', '']
+}
+df = pd.DataFrame(data)
+
+columnDefs = [
+    {
+        "headerName": "",
+        "cellRenderer": "DMC_Card",
+    },
+    {
+        "field": "comments",
+        "editable": True,
+        "cellEditorPopup": True,
+        "cellEditor": "agLargeTextCellEditor",
+        "minWidth": 300,
+    },
+]
+
+grid = dag.AgGrid(
+    columnDefs=columnDefs,
+    rowData=df.to_dict("records"),
+    columnSize="autoSize",
+    dashGridOptions={"rowHeight": 100}
+)
+
+
+app = Dash(__name__)
+
+app.layout = dmc.MantineProvider(html.Div(
+    [
+        dcc.Markdown("Example of cellRenderer with dash-mantine-components Card"),
+        grid,
+    ],
+    style={"margin": 20},
+), forceColorScheme="light")
+
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True)
+
+
+"""
+Put the following in the dashAgGridComponentFunctions.js file in the assets folder
+
+---------------
+
+var dagcomponentfuncs = window.dashAgGridComponentFunctions = window.dashAgGridComponentFunctions || {};
+
+
+
+dagcomponentfuncs.DMC_Card = function (props) {
+    return React.createElement(
+        window.dash_mantine_components.Card,
+        {
+            withBorder:true
+        },
+        React.createElement(
+            window.dash_mantine_components.Text,
+            {c:"dimmed", tt: "uppercase", fw:700},
+            props.data.stats
+        ),
+        React.createElement(
+            window.dash_mantine_components.Text,
+            {size: "lg"},
+            props.data.results
+        ),
+        React.createElement(
+            window.dash_mantine_components.Text,
+            {size: "sm", c: (props.data.change > 0) ? "green" : "red"},
+            props.data.change + "%"
+        )
+    );
+};
+
+
+
+"""

--- a/help_center/aggrid/assets/dashAgGridComponentFunctions.js
+++ b/help_center/aggrid/assets/dashAgGridComponentFunctions.js
@@ -1,0 +1,66 @@
+
+var dagcomponentfuncs = window.dashAgGridComponentFunctions = window.dashAgGridComponentFunctions || {};
+
+dagcomponentfuncs.DMC_Button = function (props) {
+    const {setData, data} = props;
+
+    function onClick() {
+        setData();
+    }
+    let leftIcon, rightIcon;
+    if (props.leftIcon) {
+        leftIcon = React.createElement(window.dash_iconify.DashIconify, {
+            icon: props.leftIcon,
+        });
+    }
+    if (props.rightIcon) {
+        rightIcon = React.createElement(window.dash_iconify.DashIconify, {
+            icon: props.rightIcon,
+        });
+    }
+    return React.createElement(
+        window.dash_mantine_components.Button,
+        {
+            onClick,
+            variant: props.variant,
+            color: props.color,
+            leftSection: leftIcon,
+            rightSection: rightIcon,
+            radius: props.radius,
+            style: {
+                margin: props.margin,
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+            },
+        },
+        props.value
+    );
+};
+
+
+dagcomponentfuncs.DMC_Card = function (props) {
+    return React.createElement(
+        window.dash_mantine_components.Card,
+        {
+            withBorder:true
+        },
+        React.createElement(
+            window.dash_mantine_components.Text,
+            {c:"dimmed", tt: "uppercase", fw:700},
+            props.data.stats
+        ),
+        React.createElement(
+            window.dash_mantine_components.Text,
+            {size: "lg"},
+            props.data.results
+        ),
+        React.createElement(
+            window.dash_mantine_components.Text,
+            {size: "sm", c: (props.data.change > 0) ? "green" : "red"},
+            props.data.change + "%"
+        )
+    );
+};
+
+

--- a/help_center/theme/assets/theme.css
+++ b/help_center/theme/assets/theme.css
@@ -10,6 +10,19 @@
   }
 }
 
+.button-custom-variants {
+  &[data-variant='danger'] {
+    background-color: var(--mantine-color-red-9);
+    color: var(--mantine-color-red-0);
+  }
+
+  &[data-variant='primary'] {
+    background: linear-gradient(45deg, #4b6cb7 10%, #253b67 90%);
+    color: var(--mantine-color-white);
+    border-width: 0;
+  }
+}
+
 
 /* Use `&:focus` when you want focus ring to be visible when control is clicked */
 .focus {
@@ -39,23 +52,4 @@
   }
 }
 
-
-
-.shadow-input {
-   border-color: transparent;
-
-    &:focus-within {
-      outline: 1px solid black;;
-      border-color: transparent;
-  }
-}
-
-.task-container:has(.mantine-Checkbox-root[data-checked]) .mantine-TextInput-input {
-    text-decoration: line-through;
-    color: gray;
-}
-
-.task-del-button:hover {
-    color: red;
-}
 

--- a/help_center/theme/assets/theme.css
+++ b/help_center/theme/assets/theme.css
@@ -38,3 +38,24 @@
     color: var(--mantine-color-dimmed);
   }
 }
+
+
+
+.shadow-input {
+   border-color: transparent;
+
+    &:focus-within {
+      outline: 1px solid black;;
+      border-color: transparent;
+  }
+}
+
+.task-container:has(.mantine-Checkbox-root[data-checked]) .mantine-TextInput-input {
+    text-decoration: line-through;
+    color: gray;
+}
+
+.task-del-button:hover {
+    color: red;
+}
+

--- a/help_center/theme/button_custom_variants.py
+++ b/help_center/theme/button_custom_variants.py
@@ -1,0 +1,34 @@
+import dash_mantine_components as dmc
+from dash import Dash, _dash_renderer
+_dash_renderer._set_react_version("18.2.0")
+
+app = Dash(external_stylesheets=dmc.styles.ALL)
+
+layout = dmc.Box([
+    dmc.Title("Button  Custom Variants Demo"),
+    dmc.Text("To add new Button variants, define a class in the .css file in /assets using the data-variant attribute. "),
+    dmc.Text("Add the new variants to the `theme` so they available in all `Button` components in your app.", mb="md"),
+    dmc.Group([
+
+        dmc.Button(
+            "Danger Variant",
+            variant="danger",
+        ),
+        dmc.Button(
+            "Pimary Variant",
+            variant="primary",
+        ),
+    ])
+])
+
+app.layout = dmc.MantineProvider(
+   children=layout,
+    theme={
+        "components": {
+            "Button": {"classNames": {"root": "button-custom-variants"}}
+        }
+    }
+)
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
- added examples of ag-grid cell renderers to help center
- added note that child buttons in `ButtonGroup` should not be wrapped in other elements.  closes #138 
- added example of adding variants to buttons and added a custom variants section in theme object section