### PR TITLE
update poetry install

### DIFF
--- a/render/build.sh
+++ b/render/build.sh
@@ -1,2 +1,2 @@
 pip install poetry
-poetry install
+poetry install --no-root


### PR DESCRIPTION
Render stopped working with this error message:

> Warning: The current project could not be installed: No file/folder found for package dmc-docs
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
In a future version of Poetry this warning will become an error!

This might be a fix  https://github.com/python-poetry/poetry/issues/8662  
added --no-root