### PR TITLE
update for new props

### DIFF
--- a/docs/avatar/allowedinitialscolors.py
+++ b/docs/avatar/allowedinitialscolors.py
@@ -1,0 +1,18 @@
+import dash_mantine_components as dmc
+
+names = [
+    "John Doe",
+    "Jane Mol",
+    "Alex Lump",
+    "Sarah Condor",
+    "Mike Johnson",
+    "Kate Kok",
+    "Tom Smith",
+]
+
+component = dmc.Group(
+    [
+        dmc.Avatar(name=n, color="initials", allowedInitialsColors=["blue", "red"])
+        for n in names
+    ]
+)

--- a/docs/avatar/avatar.md
+++ b/docs/avatar/avatar.md
@@ -16,8 +16,14 @@ category: Data Display
 To display initials instead of the default placeholder, set name prop to the name of the person, for example,
 `name='John Doe'`. If the name is set, you can use `color='initials'` to generate color based on the name:
 
-
 .. exec::docs.avatar.initials
+
+### Allowed initials colors
+By default, all colors from the default theme are allowed for initials, you can restrict them by providing 
+`allowedInitialsColors` prop with an array of colors. Note that the default colors array does not include custom
+colors defined in the theme, you need to provide them manually if needed.
+
+.. exec::docs.avatar.allowedinitialscolors
 
 ### Size, Radius and Variant
 

--- a/docs/center/center.md
+++ b/docs/center/center.md
@@ -12,6 +12,13 @@ category: Layout
 
 .. exec::docs.center.simple
 
+### Inline
+
+To use `Center` with inline elements set `inline` prop. For example, you can center link icon and label:
+
+.. exec::docs.center.inline
+
+
 ### Styles API
 
 | Name | Static selector    | Description  |

--- a/docs/center/inline.py
+++ b/docs/center/inline.py
@@ -1,0 +1,20 @@
+import dash_mantine_components as dmc
+from dash_iconify import DashIconify
+
+component = dmc.Box(
+    dmc.Anchor(
+        href="https://mantine.dev",
+        target="_blank",
+        children=dmc.Center(
+            [
+                DashIconify(
+                    icon="tabler:arrow-left",  # Use the Tabler Arrow Left icon
+                    width=12,
+                    height=12,
+                ),
+                dmc.Box("Back to Mantine website", ml=5),
+            ],
+            inline=True,
+        ),
+    )
+)

--- a/docs/grid/container.py
+++ b/docs/grid/container.py
@@ -7,13 +7,14 @@ style = {
 }
 
 component = html.Div(
+    # Wrapper div is added for demonstration purposes only,
+    # it is not required in real projects
     dmc.Grid(
         children=[
             dmc.GridCol(html.Div("1", style=style), span={"base": 12, "md": 6, "lg": 3}),
             dmc.GridCol(html.Div("2", style=style), span={"base": 12, "md": 6, "lg": 3}),
             dmc.GridCol(html.Div("3", style=style), span={"base": 12, "md": 6, "lg": 3}),
             dmc.GridCol(html.Div("4", style=style), span={"base": 12, "md": 6, "lg": 3}),
-            dmc.GridCol(html.Div("5", style=style), span={"base": 12, "md": 6, "lg": 3}),
         ],
         gutter="xl",
         type="container",

--- a/docs/grid/container.py
+++ b/docs/grid/container.py
@@ -1,0 +1,29 @@
+import dash_mantine_components as dmc
+from dash import html
+
+style = {
+    "border": f"1px solid {dmc.DEFAULT_THEME['colors']['indigo'][4]}",
+    "textAlign": "center",
+}
+
+component = html.Div(
+    dmc.Grid(
+        children=[
+            dmc.GridCol(html.Div("1", style=style), span={"base": 12, "md": 6, "lg": 3}),
+            dmc.GridCol(html.Div("2", style=style), span={"base": 12, "md": 6, "lg": 3}),
+            dmc.GridCol(html.Div("3", style=style), span={"base": 12, "md": 6, "lg": 3}),
+            dmc.GridCol(html.Div("4", style=style), span={"base": 12, "md": 6, "lg": 3}),
+            dmc.GridCol(html.Div("5", style=style), span={"base": 12, "md": 6, "lg": 3}),
+        ],
+        gutter="xl",
+        type="container",
+        breakpoints={
+            "xs": "100px",
+            "sm": "200px",
+            "md": "300px",
+            "lg": "400px",
+            "xl": "500px",
+        },
+    ),
+    style={"resize": 'horizontal', "overflow": 'hidden', "maxWidth": '100%', "margin": 24 },
+)

--- a/docs/grid/grid.md
+++ b/docs/grid/grid.md
@@ -121,6 +121,18 @@ In the following example, first column takes 50% with 12 span (12/24), second an
 
 .. exec::docs.grid.columns
 
+### Container queries
+To use [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries) instead 
+of media queries, set `type='container'`. With container queries, all responsive values are adjusted based on the
+container width, not the viewport width.
+
+Note that, when using container queries, it is also required to set `breakpoints` prop to the exact container width values.
+
+To see how the grid changes, resize the root element of the demo with the resize handle located at the bottom right
+corner of the demo:
+
+.. exec::docs.grid.container
+
 ### overflow: hidden
 By default, `Grid` has `overflow: visible` style on the root element. In some cases you might want to change it to
 `overflow: hidden` to prevent negative margins from overflowing the grid container. For example, if you use `Grid` 

--- a/docs/simplegrid/container.py
+++ b/docs/simplegrid/container.py
@@ -1,0 +1,24 @@
+import dash_mantine_components as dmc
+from dash import html
+
+style = {
+    "border": f"1px solid {dmc.DEFAULT_THEME['colors']['indigo'][4]}",
+    "textAlign": "center",
+}
+
+html.Div(
+    dmc.SimpleGrid(
+        type="container",
+        cols={"base": 1, "300px": 2, "500px": 5},
+        spacing={"base": 10, "300px": "xl"},
+        children=[
+            html.Div("1", style=style),
+            html.Div("2", style=style),
+            html.Div("3", style=style),
+            html.Div("4", style=style),
+            html.Div("5", style=style),
+        ],
+        p="xs",
+    ),
+    style={"resize": "horizontal", "overflow": "hidden", "maxWidth": "100%"},
+)

--- a/docs/simplegrid/container.py
+++ b/docs/simplegrid/container.py
@@ -6,7 +6,9 @@ style = {
     "textAlign": "center",
 }
 
-html.Div(
+component = html.Div(
+    # Wrapper div is added for demonstration purposes only,
+    # it is not required in real projects
     dmc.SimpleGrid(
         type="container",
         cols={"base": 1, "300px": 2, "500px": 5},

--- a/docs/simplegrid/simplegrid.md
+++ b/docs/simplegrid/simplegrid.md
@@ -65,6 +65,21 @@ Resize browser to see breakpoints behavior.
 
 .. exec::docs.simplegrid.responsive
 
+### Container queries
+To use [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries) instead
+of media queries, set `type='container'`. With container queries, grid columns and spacing will be adjusted based on the
+container width, not the viewport width.
+
+Note that, when using container queries, `cols`, `spacing` and `verticalSpacing` props cannot reference `theme.breakpoints`
+values in keys. It is required to use exact `px` or `em` values.
+
+To see how the grid changes, resize the root element of the demo with the resize handle located at the bottom right
+corner of the demo:
+
+
+.. exec::docs.simplegrid.container
+
+
 ### Styles API
 
 


### PR DESCRIPTION
**Merge after 0.15.2 is released** 

- added container query examples for `Grid` and `SimpleGrid`
- added `inline` example to `Center` 
- added `allowedInitialsColors` example for `Avatar`

examples checked and updated -run with 0.15.2  and good to go after release