### PR TITLE
After 0 15 2 docs updates

### DIFF
--- a/docs/grid/grid.md
+++ b/docs/grid/grid.md
@@ -78,7 +78,7 @@ Once children columns span and offset sum exceeds `columns` prop (defaults to 12
 ### Justify and Align
 
 Since grid is a flexbox container, you can control justify-content and align-items properties by using `justify` and 
-`align` props respectively.
+`align` props respectively. Note the minimum height set on column 2 and 3.
 
 ```python
 import dash_mantine_components as dmc
@@ -87,12 +87,12 @@ from dash import html
 dmc.Grid(
     children=[
         dmc.GridCol(html.Div("1"), span=4),
-        dmc.GridCol(html.Div("2"), span=4),
-        dmc.GridCol(html.Div("3"), span=4),
+        dmc.GridCol(html.Div("2", style={"minHeight":80}), span=4),
+        dmc.GridCol(html.Div("3", style={"minHeight":120}), span=4),
     ],
     justify="center",
-    align="center",
-    gutter="xl",
+    align="stretch",
+
 )
 ```
 

--- a/docs/grid/justify.py
+++ b/docs/grid/justify.py
@@ -24,7 +24,5 @@ configurator.add_select(
 configurator.add_select(
     "align", ["stretch", "center", "flex-end", "flex-start"], "stretch"
 )
-configurator.add_switch("grow", False)
-configurator.add_slider("gutter", "md")
 
 component = configurator.panel

--- a/docs/styles-api/styles.md
+++ b/docs/styles-api/styles.md
@@ -162,7 +162,7 @@ The `styles` property works similarly to `classNames`, but applies inline styles
 specificity than classes, so you cannot override them with classes without using `!important`. You cannot use 
 pseudo-classes (for example, `:hover`, `:first-of-type`) and media queries with inline styles.
 
-> **styles property usage**
+> Styles Property Usage
 >
 > While some examples may use the `styles` property for convenience, it is recommended to use `classNames` or `className`
 > as the primary means of styling components, as it is more flexible and has better performance.

--- a/lib/directives/source.py
+++ b/lib/directives/source.py
@@ -7,9 +7,12 @@ from markdown2dash import SourceCode
 
 
 class SC(SourceCode):
-    NAME = "source"
+    NAME = "sourcetabs"
 
     def render(self, renderer, title: str, content: str, **options) -> Component:
+        defaultExpanded = options.pop("defaultExpanded", "false")
+        withExpandedButton = options.pop("withExpandedButton", "true")
+
         mapping = {
             "py": {"language": "python", "icon": DashIconify(icon="devicon:python")},
             "css": {"language": "css", "icon": DashIconify(icon="devicon:css3")},
@@ -26,4 +29,15 @@ class SC(SourceCode):
                     "icon": mapping[extension]["icon"],
                 }
             )
-        return dmc.CodeHighlightTabs(code=code)
+        return dmc.CodeHighlightTabs(code=code, defaultExpanded=defaultExpanded=="true", withExpandButton=withExpandedButton=='true' )
+
+
+"""
+sample usage:
+
+
+.. sourcetabs::docs/alert/auto.py, assets/styles.css
+    :defaultExpanded: false
+    :withExpandedButton: true
+
+"""

--- a/run.py
+++ b/run.py
@@ -38,4 +38,4 @@ app.layout = create_appshell(dash.page_registry.values())
 server = app.server
 
 if __name__ == "__main__":
-    app.run_server(debug=True, port=8052)
+    app.run(debug=True, port=8052)


### PR DESCRIPTION
various updates 
- change run_server to run for dash 3
- fix console error on styles api page for `<p> cannot appear as a descendant of <p>`  It was from bold inside a blockquote
- update to add ability to have tabs in source code displays
