### PR TITLE
1.0.0rc1 update2

### DIFF
--- a/assets/examples/light-dark-demo.css
+++ b/assets/examples/light-dark-demo.css
@@ -1,0 +1,9 @@
+/* applied in light color-scheme */
+.light-dark-demo {
+    background-color: yellow
+}
+
+/* applied in dark color-scheme */
+[data-mantine-color-scheme='dark'] .light-dark-demo {
+     background-color: red
+}

--- a/assets/examples/light-dark-demo.css
+++ b/assets/examples/light-dark-demo.css
@@ -1,9 +1,9 @@
 /* applied in light color-scheme */
 .light-dark-demo {
-    background-color: yellow
+    background-color: #ffec99
 }
 
 /* applied in dark color-scheme */
-[data-mantine-color-scheme='dark'] .light-dark-demo {
-     background-color: red
+ [data-mantine-color-scheme='dark'] .light-dark-demo {
+     background-color: #ff6b6b
 }

--- a/assets/examples/light-dark-var.css
+++ b/assets/examples/light-dark-var.css
@@ -17,7 +17,20 @@ You can also use mantine colors
 :root[data-mantine-color-scheme="dark"] {
   --my-light-dark-colors: var(--mantine-color-blue-1);
 }
+*/
 
+
+/*
+The  --mantine-color-body CSS variable is used for body background and as background color
+ of some components (Modal, Paper, etc.).  You can change it like this:
+
+:root {
+  --mantine-color-body: #f9f9f9;
+}
+
+:root[data-mantine-color-scheme="dark"] {
+  --mantine-color-body: #333;
+}
 
 
 */

--- a/assets/examples/light-dark-var.css
+++ b/assets/examples/light-dark-var.css
@@ -1,0 +1,23 @@
+
+:root {
+  --my-light-dark-colors: aliceblue;
+}
+
+:root[data-mantine-color-scheme="dark"] {
+  --my-light-dark-colors: blue;
+}
+
+/*
+You can also use mantine colors
+
+:root {
+  --my-light-dark-colors: var(--mantine-color-blue-1);
+}
+
+:root[data-mantine-color-scheme="dark"] {
+  --my-light-dark-colors: var(--mantine-color-blue-1);
+}
+
+
+
+*/

--- a/docs/carousel/autoplay.py
+++ b/docs/carousel/autoplay.py
@@ -3,7 +3,6 @@ import dash_mantine_components as dmc
 from dash import html, callback, Input, Output
 
 component = html.Div([
-    dmc.Button("start", id="carousel-autoplay-btn", variant="outline", color="black", n_clicks=0),
     dmc.Carousel(
         [
             dmc.CarouselSlide(dmc.Center("Slide-1", bg="blue", c="white", p=60)),
@@ -13,15 +12,6 @@ component = html.Div([
         id="carousel-autoplay",
         mt="sm",
         loop=True,
-        autoplay=False,  # Default delay is 4000ms
+        autoplay=True,  # Default delay is 4000ms
     )
 ])
-
-@callback(
-    Output("carousel-autoplay", "autoplay"),
-    Input("carousel-autoplay-btn", "n_clicks")
-)
-def start(n):
-    if n > 0:
-        return True
-    return dash.no_update

--- a/docs/carousel/carousel.md
+++ b/docs/carousel/carousel.md
@@ -194,6 +194,13 @@ Be sure to give a unique id to each carousel in the app.
 
 .. exec::docs.carousel.tabs
 
+
+### Limitation: draggable prop
+In dash-mantine-components version 0.14.7 and above, setting `draggable=False` has no effect. This happens because DMC
+uses a different version of Embla Carousel than the upstream Mantine library.
+
+We expect this to work again once Mantine upgrades to Embla Carousel v8.0 or later.
+
 ### Styles API
 
 #### Carousel selectors

--- a/docs/code-highlight/code-highlight.md
+++ b/docs/code-highlight/code-highlight.md
@@ -58,6 +58,12 @@ The `code` prop is a list of dictionaries, where each dictionary defines a tab. 
 - `icon`: An optional component to display to the left of the fileName.
 
 
+**Limitations**
+
+In Dash 3.0, avoid using the `icon`  in tabs if your app includes a theme-switching component, as icons may cause errors when switching themes. 
+A fix for this issue may be introduced in a future Dash release.
+
+
 
 .. exec::docs.code-highlight.tabs
     :code: false
@@ -71,13 +77,13 @@ code = [
         "fileName": "demo.py",
         "code": demo_py, # your code string here
         "language": "python",
-        "icon": DashIconify(icon="vscode-icons:file-type-reactts", width=20),
+    #    "icon": DashIconify(icon="vscode-icons:file-type-python", width=20), don't use with dash 3
     },
     {
         "fileName": "styles.css",
         "code":styles_css, # your code string here
         "language": "css",
-        "icon": DashIconify(icon="vscode-icons:file-type-css", width=20),
+    #    "icon": DashIconify(icon="vscode-icons:file-type-css", width=20), don't use with dash 3
     },    
 ]
 

--- a/docs/code-highlight/expandable.py
+++ b/docs/code-highlight/expandable.py
@@ -31,13 +31,13 @@ code = [
         "fileName": "demo.py",
         "code": demo_py,
         "language": "python",
-        "icon": DashIconify(icon="vscode-icons:file-type-reactts", width=20),
+    #    "icon": DashIconify(icon="vscode-icons:file-type-python", width=20),
     },
     {
         "fileName": "styles.css",
         "code":styles_css,
         "language": "css",
-        "icon": DashIconify(icon="vscode-icons:file-type-css", width=20),
+    #    "icon": DashIconify(icon="vscode-icons:file-type-css", width=20),
     },
 ]
 

--- a/docs/code-highlight/tabs.py
+++ b/docs/code-highlight/tabs.py
@@ -31,13 +31,13 @@ code = [
         "fileName": "demo.py",
         "code": demo_py,
         "language": "python",
-        "icon": DashIconify(icon="vscode-icons:file-type-reactts", width=20),
+    #    "icon": DashIconify(icon="vscode-icons:file-type-python", width=20),
     },
     {
         "fileName": "styles.css",
         "code":styles_css,
         "language": "css",
-        "icon": DashIconify(icon="vscode-icons:file-type-css", width=20),
+    #    "icon": DashIconify(icon="vscode-icons:file-type-css", width=20),
     },
 ]
 

--- a/docs/colors/colors.md
+++ b/docs/colors/colors.md
@@ -224,6 +224,8 @@ background-color: light-dark(white, black);
 - The first argument applies in light mode.
 - The second argument applies in dark mode.
 
+Note that the light-dark() function is not supported in older browsers.
+
 .. exec::docs.colors.light-dark-function
 
 

--- a/docs/colors/colors.md
+++ b/docs/colors/colors.md
@@ -212,6 +212,49 @@ You can combine both props to achieve better contrast between text and backgroun
 
 .. exec::docs.colors.color_c_props
 
+### Colors in light and dark mode
+
+#### Using light-dark() CSS Function
+The [light-dark()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) function allows defining different styles for light and dark color schemes.
+
+```css
+background-color: light-dark(white, black);
+```
+
+- The first argument applies in light mode.
+- The second argument applies in dark mode.
+
+.. exec::docs.colors.light-dark-function
+
+
+#### CSS Class Names for Light/Dark Mode
+
+Since light-dark() is not supported in older browsers, you can use class-based styling instead:
+
+.. exec::docs.colors.light-dark
+    :code: false
+
+
+.. sourcetabs::docs/colors/light-dark.py, assets/examples/light-dark-demo.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+
+#### CSS Variables for Light/Dark Mode
+
+Defining CSS variables on the `:root` element allows global styling across your app, including the `body` element.
+
+Here is an example using a CSS variable:
+
+.. exec::docs.colors.light-dark-var
+    :code: false
+
+
+.. sourcetabs::docs/colors/light-dark-var.py, assets/examples/light-dark-var.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+
 ### Default colors
 
 

--- a/docs/colors/light-dark-function.py
+++ b/docs/colors/light-dark-function.py
@@ -1,0 +1,22 @@
+import dash_mantine_components as dmc
+
+component = dmc.Box([
+
+    dmc.Text(
+        "Click the theme switch in the header to see how the background changes in different modes:"
+    ),
+    # Using CSS color names
+    dmc.Text(
+        "light-dark(whitesmoke, gray)",
+        style={"backgroundColor": "light-dark(whitesmoke, gray)"},
+        p="lg",
+        m="md"
+    ),
+    # Using Mantine CSS variables
+    dmc.Text(
+        "light-dark(var(--mantine-color-blue-1), var(--mantine-color-blue-9))",
+        style={"backgroundColor": "light-dark(var(--mantine-color-blue-1), var(--mantine-color-blue-9))"},
+        p="lg",
+        m="md"
+    )
+])

--- a/docs/colors/light-dark-var.py
+++ b/docs/colors/light-dark-var.py
@@ -1,0 +1,14 @@
+import dash_mantine_components as dmc
+
+component = dmc.Box([
+
+    dmc.Text(
+        "Click the theme switch in the header to see how the background changes in different modes:"
+    ),
+    dmc.Text(
+        "CSS variable defined for light and dark scheme",
+        style={"backgroundColor": "var(--my-light-dark-colors"},
+        p="lg",
+        m="md"
+    ),
+])

--- a/docs/colors/light-dark.py
+++ b/docs/colors/light-dark.py
@@ -1,0 +1,14 @@
+import dash_mantine_components as dmc
+
+component = dmc.Box([
+
+    dmc.Text(
+        "Click the theme switch in the header to see how the background changes in different modes"
+    ),
+    dmc.Text(
+        "CSS class defined for light and dark scheme",
+        className="light-dark-demo",
+        p="lg",
+        m="md"
+    ),
+])

--- a/docs/linechart/line.md
+++ b/docs/linechart/line.md
@@ -54,13 +54,13 @@ Set `type="gradient"` to render a line chart with gradient fill. To customize gr
 It accepts an array of objects with `offset` and `color` properties. `offset` is a number between 0 and 100 that defines
 the position of the color in the gradient, `color` is a reference to `theme.colors` or any valid CSS color.
 
-.. exec::docs.linechart.legend
+.. exec::docs.linechart.gradient
 
 ### Legend
 To display chart legend, set `withLegend` prop. When one of the items in the legend is hovered, the corresponding data
 series is highlighted in the chart.
 
-.. exec::docs.linechart.gradient
+.. exec::docs.linechart.legend
 
 ### Legend position
 You can pass props down to recharts Legend component with `legendProps` prop. For example, setting the following will

--- a/lib/directives/source.py
+++ b/lib/directives/source.py
@@ -26,7 +26,8 @@ class SC(SourceCode):
                     "fileName": os.path.basename(file),
                     "code": open(file, "r").read(),
                     "language": mapping[extension]["language"],
-                    "icon": mapping[extension]["icon"],
+                    # remove temporarily until bug in dash 3 is fixed. https://github.com/emilhe/dash-extensions-js/issues/5
+                    # "icon": mapping[extension]["icon"],
                 }
             )
         return dmc.CodeHighlightTabs(code=code, defaultExpanded=defaultExpanded=="true", withExpandButton=withExpandedButton=='true' )


### PR DESCRIPTION
- removes the icons in CodeHightTabs because they do not render correctly in when switching between light and dark modes in dash 3.  More info https://github.com/emilhe/dash-extensions-js/issues/5
- Notes a limitation in the Carousel section about the draggable prop not working in dmc>-0.14.7  Closes dmc issue # 512.
- Adds more info on how to style colors in light and dark mode