### PR TITLE
Pr504 active navlink

### DIFF
--- a/components/navbar.py
+++ b/components/navbar.py
@@ -43,6 +43,7 @@ def create_main_link(icon, label, href, id):
         label=label,
         href=href,
         id=id,
+        active="exact"
     )
 
 
@@ -97,6 +98,7 @@ def create_content(data, idtype):
                 className="navbar-link",
                 pl=30,
                 id={"type": idtype, "index": entry["path"]},
+                active="exact"
             )
             links[entry["category"]].append(link)
 
@@ -157,21 +159,3 @@ def create_navbar_drawer(data):
         children=create_content(data, "navlink_drawer"),
         trapFocus=False,
     )
-
-
-clientside_callback(
-    """(p) => {
-        dc = dash_clientside
-        old = document.querySelectorAll('.mantine-NavLink-root[data-active]')
-        if (old) {
-            old.forEach((el) => {
-                dc.set_props((el.id.includes('{') ? JSON.parse(el.id) : el.id), {active: false})
-            })
-        }
-        newId = document.querySelector(`.mantine-NavLink-root[href="${p.split('?')[0]}"]`)
-        if (newId) {
-            dc.set_props((newId.id.includes('{') ? JSON.parse(newId.id) : newId.id), {active: true})
-        }
-    }""",
-    Input('_pages_location', "pathname"),
-)

--- a/docs/navlink/navlink.md
+++ b/docs/navlink/navlink.md
@@ -1,6 +1,6 @@
 ---
 name: NavLink
-description: Use the Navlink component to create navigation link in the side navigation bars.
+description: A Navlink component.
 endpoint: /components/navlink
 package: dash_mantine_components
 category: Navigation
@@ -10,13 +10,13 @@ category: Navigation
 
 ### Basic usage
 
-You can use dmc.NavLink's `n_clicks` property in callbacks, or you can pass `href` to make it a link.
+Use `NavLink`'s `n_clicks` property in callbacks, or you can set `href` to make it a link.
 
 .. exec::docs.navlink.basic
 
 ### Active styles
 
-Set `active` prop to add active styles to dmc.NavLink. You can customize active styles with `color` and `variant` properties.
+Set `active` prop to add active styles to `NavLink`. You can customize active styles with `color` and `variant` properties.
 
 .. exec::docs.navlink.active
     :code: false
@@ -36,9 +36,37 @@ dmc.NavLink(
 ),
 ```
 
-#### Using a callback to set active prop
+### Setting Active prop based on URL
 
-This example demonstrates how to use a callback to set the active prop of the NavLinks when the user navigates to a different page. It uses the "Dash Pages" feature but can be adapted to any other page navigation system.
+The `active` prop in `NavLink` controls whether a link is highlighted as active. It can be set manually (`True`/`False`)
+or automatically based on the current URL.  
+
+*New in dash-mantine-components > = 1.0.0*  
+
+Now, `active` can be set dynamically:  
+- `"exact"` → Active when the current pathname matches `href`.  
+- `"partial"` → Active when the current pathname starts with `href` (includes subpages).  
+
+Example:
+- User on `/page-1/subject-1` → The second and third links are active (since `"partial"` includes subpages).  
+- User on `/page-1` → Only the second link is active.  
+
+
+```python
+html.Div([
+    dmc.NavLink(label="Home", href="/home", active="exact"),
+    dmc.NavLink(label="Page 1", href="/page-1", active="partial"),
+    dmc.NavLink(label="Subject 1", href="/page-1/subject-1", active="exact"),
+])
+```
+See a complete example in Multi-Page App Example with Active Links section.  
+
+
+### Setting active prop in a callback
+
+Use a callback to set `active` prop if you are using dash-mantine-components<1.0.0
+
+This example demonstrates how to use a callback to set the `active` prop of the `NavLink` when the user navigates to a different page. It uses the "Dash Pages" feature but can be adapted to any other page navigation system.
 
 ```python
 # Create Navlinks (using dash.page_registry)
@@ -65,6 +93,50 @@ def update_navlinks(pathname):
 To create nested links put dmc.NavLink as children of another dmc.NavLink.
 
 .. exec::docs.navlink.nested
+
+
+### Multi-Page App Example with Active Links
+Here's a minimal multi-page app example using Pages. It demonstrates how `active="exact"` and `active="partial"`
+automatically apply active styles based on the current URL
+
+```python
+import dash
+import dash_mantine_components as dmc
+from dash import Dash, _dash_renderer, html
+_dash_renderer._set_react_version("18.2.0")
+
+app = Dash(external_stylesheets=dmc.styles.ALL, use_pages=True, pages_folder="")
+
+dash.register_page("home", path="/", layout=html.Div("I'm home"))
+dash.register_page("page1", path="/page-1", layout=html.Div("Info about page 1 subjects"))
+dash.register_page("page1s1", path="/page-1/sub-1", layout=html.Div("page 1 subject 1"))
+dash.register_page("page1s2", path="/page-1/sub-2", layout=html.Div("page 1 subject 2"))
+
+component = dmc.Box([
+    dmc.NavLink(label="home", href="/", active='exact'),
+    dmc.NavLink(
+            label="Page 1",
+            childrenOffset=28,
+            href="/page-1",
+            active='partial',
+            children=[
+                dmc.NavLink(label="Subject 1", href="/page-1/sub-1", active="exact"),
+                dmc.NavLink(label="Subject 2", href="/page-1/sub-2", active="exact"),
+            ],
+    ),
+    dmc.Divider(mb="lg"),
+    dash.page_container
+])
+
+
+app.layout = dmc.MantineProvider([component])
+
+if __name__ == "__main__":
+    app.run(debug=True)
+
+```
+
+Here is a complete example using 
 
 ### Styles API
 


### PR DESCRIPTION
Update docs for new `active="exact"` and `active="partial"`

- updated example in NavLink section
-  updated app to use "exact" rather than the callback to set the active links

### :construction: Do not merge before dmc PR 504 is merged and released. ###