### PR TITLE
fixed theme switch component that broke CodeHighlightTab

### DIFF
--- a/components/appshell.py
+++ b/components/appshell.py
@@ -89,16 +89,15 @@ clientside_callback(
     Input("m2d-mantine-provider", "forceColorScheme"),
 )
 
-clientside_callback(
-    "function(colorScheme) {return colorScheme}",
-    Output("m2d-mantine-provider", "forceColorScheme"),
-    Input("color-scheme-storage", "data")
-)
+
 
 clientside_callback(
-    'function(n_clicks, theme) {return theme === "dark" ? "light" : "dark"}',
-    Output("color-scheme-storage", "data"),
-    Input("color-scheme-toggle", "n_clicks"),
-    State("color-scheme-storage", "data"),
-    prevent_initial_call=True,
+    """
+    (switchOn) => {
+       document.documentElement.setAttribute('data-mantine-color-scheme', switchOn ? 'dark' : 'light');
+       return window.dash_clientside.no_update
+    }
+    """,
+    Output("docs-color-scheme-switch", "id"),
+    Input("docs-color-scheme-switch", "checked"),
 )

--- a/components/header.py
+++ b/components/header.py
@@ -67,6 +67,15 @@ def create_search(data):
     )
 
 
+theme_toggle = dmc.Switch(
+    offLabel=DashIconify(icon="radix-icons:sun", width=15, color=dmc.DEFAULT_THEME["colors"]["yellow"][8]),
+    onLabel=DashIconify(icon="radix-icons:moon", width=15, color=dmc.DEFAULT_THEME["colors"]["yellow"][6]),
+    id="docs-color-scheme-switch",
+    persistence=True,
+    color="grey",
+    size="md"
+)
+
 def create_header(data):
     return dmc.AppShellHeader(
         px=25,
@@ -103,24 +112,7 @@ def create_header(data):
                                     create_link(
                                         "bi:discord", "https://discord.gg/KuJkh4Pyq5"
                                     ),
-                                    dmc.ActionIcon(
-                                        [
-                                            DashIconify(
-                                                icon="radix-icons:sun",
-                                                width=25,
-                                                id="light-theme-icon",
-                                            ),
-                                            DashIconify(
-                                                icon="radix-icons:moon",
-                                                width=25,
-                                                id="dark-theme-icon",
-                                            ),
-                                        ],
-                                        variant="transparent",
-                                        color="yellow",
-                                        id="color-scheme-toggle",
-                                        size="lg",
-                                    ),
+                                    theme_toggle,
                                     dmc.ActionIcon(
                                         DashIconify(
                                             icon="radix-icons:hamburger-menu",

--- a/docs/code-highlight/code-highlight.md
+++ b/docs/code-highlight/code-highlight.md
@@ -58,13 +58,6 @@ The `code` prop is a list of dictionaries, where each dictionary defines a tab. 
 - `icon`: An optional component to display to the left of the fileName.
 
 
-**Limitations**
-
-In Dash 3.0, avoid using the `icon`  in tabs if your app includes a theme-switching component, as icons may cause errors when switching themes. 
-A fix for this issue may be introduced in a future Dash release.
-
-
-
 .. exec::docs.code-highlight.tabs
     :code: false
 
@@ -77,13 +70,13 @@ code = [
         "fileName": "demo.py",
         "code": demo_py, # your code string here
         "language": "python",
-    #    "icon": DashIconify(icon="vscode-icons:file-type-python", width=20), don't use with dash 3
+        "icon": DashIconify(icon="vscode-icons:file-type-python", width=20), don't use with dash 3
     },
     {
         "fileName": "styles.css",
         "code":styles_css, # your code string here
         "language": "css",
-    #    "icon": DashIconify(icon="vscode-icons:file-type-css", width=20), don't use with dash 3
+        "icon": DashIconify(icon="vscode-icons:file-type-css", width=20), don't use with dash 3
     },    
 ]
 

--- a/docs/code-highlight/expandable.py
+++ b/docs/code-highlight/expandable.py
@@ -31,13 +31,13 @@ code = [
         "fileName": "demo.py",
         "code": demo_py,
         "language": "python",
-    #    "icon": DashIconify(icon="vscode-icons:file-type-python", width=20),
+        "icon": DashIconify(icon="vscode-icons:file-type-python", width=20),
     },
     {
         "fileName": "styles.css",
         "code":styles_css,
         "language": "css",
-    #    "icon": DashIconify(icon="vscode-icons:file-type-css", width=20),
+        "icon": DashIconify(icon="vscode-icons:file-type-css", width=20),
     },
 ]
 

--- a/docs/code-highlight/tabs.py
+++ b/docs/code-highlight/tabs.py
@@ -31,13 +31,13 @@ code = [
         "fileName": "demo.py",
         "code": demo_py,
         "language": "python",
-    #    "icon": DashIconify(icon="vscode-icons:file-type-python", width=20),
+        "icon": DashIconify(icon="vscode-icons:file-type-python", width=20),
     },
     {
         "fileName": "styles.css",
         "code":styles_css,
         "language": "css",
-    #    "icon": DashIconify(icon="vscode-icons:file-type-css", width=20),
+        "icon": DashIconify(icon="vscode-icons:file-type-css", width=20),
     },
 ]
 

--- a/docs/ringprogress/label.py
+++ b/docs/ringprogress/label.py
@@ -17,7 +17,7 @@ component = dmc.Group(
             label=dmc.Text("App data usage", size="xs", ta="center"),
         ),
         dmc.RingProgress(
-            id="ring-progress-label2",
+            id="ring-progress-label3",
             sections=[{"value": 60, "color": "green"}, {"value": 5, "color": "yellow"}],
             label=dmc.Center(
                 dmc.ActionIcon(

--- a/docs/theme-switch-components/themeswitch.md
+++ b/docs/theme-switch-components/themeswitch.md
@@ -9,57 +9,62 @@ order: 10  # sets order in navbar section
 
 .. toc::
 
-### Example 1
+### Mantine Light and dark themes
 
-This simple example demonstrates how to toggle between light and dark modes using  `ActionIcon` as the theme switch component.
-It's similar to the theme switcher used in the Mantine documentation.
+Mantine sets the light and dark color schemes using the `data-mantine-color-scheme` attribute on the `<html>` element.
+This allows it to apply global styles dynamically based on the theme.
+
+To switch themes in a Dash app you can set the `data-mantine-color-scheme` in a clientside callback.
+
+### Example 1 Theme Toggle
+
+This example demonstrates how to toggle between light and dark modes using  `ActionIcon` as the theme switch component.
+
+.. exec::docs.theme-switch-components.themeswitch
+
+### Example 2 Theme Switch
+
+This example shows how to use the `Switch` component with icon labels to create a theme switch component.   The `Switch`
+is set with `persistence=True` to retain the selected theme even after a browser refresh.
+
+This is the theme switch used in these docs.  Click on the switch in the header to change themes.
+
+Here is a complete minimal example:
 
 ```python
 
 import dash_mantine_components as dmc
 from dash_iconify import DashIconify
-from dash import Dash, Input, Output, State, callback, _dash_renderer
+from dash import Dash, Input, Output, State, callback, _dash_renderer, html, clientside_callback
 _dash_renderer._set_react_version("18.2.0")
 
-theme_toggle = dmc.ActionIcon(
-    [
-        dmc.Paper(DashIconify(icon="radix-icons:sun", width=25), darkHidden=True),
-        dmc.Paper(DashIconify(icon="radix-icons:moon", width=25), lightHidden=True),
-    ],
-    variant="transparent",
-    color="yellow",
-    id="color-scheme-toggle",
-    size="lg",
-    ms="auto",
+theme_toggle = dmc.Switch(
+    offLabel=DashIconify(icon="radix-icons:sun", width=15, color=dmc.DEFAULT_THEME["colors"]["yellow"][8]),
+    onLabel=DashIconify(icon="radix-icons:moon", width=15, color=dmc.DEFAULT_THEME["colors"]["yellow"][6]),
+    id="color-scheme-switch",
+    persistence=True,
+    color="grey",
 )
 
 app = Dash(external_stylesheets=dmc.styles.ALL)
 
 app.layout = dmc.MantineProvider(
     [theme_toggle, dmc.Text("Your page content")],
-    id="mantine-provider",
-    forceColorScheme="light",
 )
 
-
-@callback(
-    Output("mantine-provider", "forceColorScheme"),
-    Input("color-scheme-toggle", "n_clicks"),
-    State("mantine-provider", "forceColorScheme"),
-    prevent_initial_call=True,
+clientside_callback(
+    """
+    (switchOn) => {
+       document.documentElement.setAttribute('data-mantine-color-scheme', switchOn ? 'dark' : 'light');
+       return window.dash_clientside.no_update
+    }
+    """,
+    Output("color-scheme-switch", "id"),
+    Input("color-scheme-switch", "checked"),
 )
-def switch_theme(_, theme):
-    return "dark" if theme == "light" else "light"
 
 
 if __name__ == "__main__":
     app.run(debug=True)
+
 ```
-
-### Example 2: Theme Switch with Clientside Callback  
-
-This example shows how to use the `Switch` component with icon labels to create a theme switch component. A clientside 
-callback updates the `data-mantine-color-scheme` attribute to `'light'` or `'dark'`.  The `Switch` is set with 
-`persistence=True` to retain the selected theme even after a browser refresh.
-
-.. exec::docs.theme-switch-components.themeswitch2

--- a/docs/theme-switch-components/themeswitch.py
+++ b/docs/theme-switch-components/themeswitch.py
@@ -1,0 +1,37 @@
+
+import dash_mantine_components as dmc
+from dash_iconify import DashIconify
+from dash import Dash, Input, Output, clientside_callback, _dash_renderer
+_dash_renderer._set_react_version("18.2.0")
+
+theme_toggle = dmc.ActionIcon(
+    [
+        dmc.Paper(DashIconify(icon="radix-icons:sun", width=25), darkHidden=True),
+        dmc.Paper(DashIconify(icon="radix-icons:moon", width=25), lightHidden=True),
+    ],
+    variant="transparent",
+    color="yellow",
+    id="color-scheme-toggle",
+    size="lg",
+)
+
+
+component=dmc.Group([
+    dmc.Text("Theme Switch Demo"),
+    theme_toggle
+])
+
+
+clientside_callback(
+    """
+    (n) => {
+        document.documentElement.setAttribute(
+            'data-mantine-color-scheme',
+            (n % 2) ? 'dark' : 'light'
+        );
+        return window.dash_clientside.no_update      
+    }
+    """,
+    Output("color-scheme-toggle", "id"),
+    Input("color-scheme-toggle", "n_clicks"),
+)

--- a/lib/directives/source.py
+++ b/lib/directives/source.py
@@ -26,8 +26,7 @@ class SC(SourceCode):
                     "fileName": os.path.basename(file),
                     "code": open(file, "r").read(),
                     "language": mapping[extension]["language"],
-                    # remove temporarily until bug in dash 3 is fixed. https://github.com/emilhe/dash-extensions-js/issues/5
-                    # "icon": mapping[extension]["icon"],
+                    "icon": mapping[extension]["icon"],
                 }
             )
         return dmc.CodeHighlightTabs(code=code, defaultExpanded=defaultExpanded=="true", withExpandButton=withExpandedButton=='true' )


### PR DESCRIPTION
In dash 3 the `CodeHighlightTabs` with icons generated errors when switching themes.  The error only happened when the theme was updated by setting the `forceColorScheme` prop on the  `MantineProvider`.  If the theme is updated by setting the `data-mantine-color-scheme` attribute then the error did not occur.

Also updated the theme switch component examples to show the correct way to switch themes.