### PR TITLE
Docs(table): use `withTableBorder` to resolve `TypeError`

### DIFF
--- a/docs/table/table.md
+++ b/docs/table/table.md
@@ -48,7 +48,7 @@ import dash_mantine_components as dmc
 dmc.Table(
     striped=True,
     highlightOnHover=True,
-    withBorder=True,
+    withTableBorder=True,
     withColumnBorders=True,
     data={...}
 )


### PR DESCRIPTION
Resolves `TypeError` when running the example in version 0.15.3.

```python
TypeError: The `dash_mantine_components.Table` component (version 0.15.3) received an unexpected keyword argument: `withBorder`
```