### PR TITLE
 add light-dark examples to charts

### DIFF
--- a/assets/examples/area-color.css
+++ b/assets/examples/area-color.css
@@ -1,0 +1,8 @@
+:root {
+   --area-color: var(--mantine-color-orange-8)
+}
+
+:root[data-mantine-color-scheme="dark"] {
+  --area-color: var(--mantine-color-lime-4);
+}
+

--- a/assets/examples/area-color.css
+++ b/assets/examples/area-color.css
@@ -1,8 +1,0 @@
-:root {
-   --area-color: var(--mantine-color-orange-8)
-}
-
-:root[data-mantine-color-scheme="dark"] {
-  --area-color: var(--mantine-color-lime-4);
-}
-

--- a/assets/examples/chart-color.css
+++ b/assets/examples/chart-color.css
@@ -1,0 +1,8 @@
+:root {
+   --chart-color: var(--mantine-color-orange-8)
+}
+
+:root[data-mantine-color-scheme="dark"] {
+  --chart-color: var(--mantine-color-lime-4);
+}
+

--- a/assets/examples/chart-grid-text-colors.css
+++ b/assets/examples/chart-grid-text-colors.css
@@ -1,0 +1,10 @@
+
+.chart-grid-text-colors {
+  --chart-grid-color: var(--mantine-color-blue-5);
+  --chart-text-color: var(--mantine-color-blue-8);
+}
+
+[data-mantine-color-scheme='dark'] .chart-grid-text-colors {
+  --chart-grid-color: var(--mantine-color-blue-3);
+  --chart-text-color: var(--mantine-color-blue-2);
+}

--- a/docs/areachart/areachart.md
+++ b/docs/areachart/areachart.md
@@ -196,6 +196,21 @@ dmc.AreaChart(
 
 ```
 
+### Change area color depending on color scheme
+You can use CSS variables in color property. Learn more in the Theming section under [Colors.](/colors#colors-in-light-and-dark-mode)
+
+Example of area that is dark orange in light mode and lime in dark mode:
+
+
+.. exec::docs.areachart.areacolor-light-dark
+    :code: false
+
+
+.. sourcetabs::docs/areachart/areacolor-light-dark.py, assets/examples/area-color.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+
 ### Stroke dash array
 Set `strokeDasharray` prop to control the stroke dash array of the grid and cursor lines. The value represent the
 lengths of alternating dashes and gaps. For example, strokeDasharray="10 5" will render a dashed line with 10px dashes
@@ -203,6 +218,38 @@ and 5px gaps.
 
 
 .. exec::docs.areachart.strokedasharray
+
+### Grid and text colors
+Use `--chart-grid-color` and `--chart-text-color` to change colors of grid lines and text within the chart. 
+With CSS , you can change colors depending on color scheme.  Learn more in the Theming section under [Colors.](/colors#colors-in-light-and-dark-mode)
+
+
+
+.. exec::docs.areachart.grid-text-color-light-dark
+    :code: false
+
+
+.. sourcetabs::docs/areachart/grid-text-color-light-dark.py, assets/examples/chart-grid-text-colors.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+If your application has only one color scheme, you can use gridColor and textColor props instead of CSS variables:
+
+```python
+dmc.AreaChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    type="stacked",
+    gridColor="gray.5",
+    textColor = "gray.9",
+    series=[
+        {"name": "Apples", "color": "indigo.6"},
+        {"name": "Oranges", "color": "blue.6"},
+        {"name": "Tomatoes", "color": "teal.6"},
+    ],
+)
+```
 
 ### Tooltip animation
 By default, tooltip animation is disabled. To enable it, set `tooltipAnimationDuration` prop to a number of

--- a/docs/areachart/areachart.md
+++ b/docs/areachart/areachart.md
@@ -206,7 +206,7 @@ Example of area that is dark orange in light mode and lime in dark mode:
     :code: false
 
 
-.. sourcetabs::docs/areachart/areacolor-light-dark.py, assets/examples/area-color.css
+.. sourcetabs::docs/areachart/areacolor-light-dark.py, assets/examples/chart-color.css
     :defaultExpanded: true
     :withExpandedButton: true
 
@@ -233,7 +233,7 @@ With CSS , you can change colors depending on color scheme.  Learn more in the T
     :defaultExpanded: true
     :withExpandedButton: true
 
-If your application has only one color scheme, you can use gridColor and textColor props instead of CSS variables:
+If your application has only one color scheme, you can use `gridColor` and `textColor` props instead of CSS variables:
 
 ```python
 dmc.AreaChart(

--- a/docs/areachart/areacolor-light-dark.py
+++ b/docs/areachart/areacolor-light-dark.py
@@ -6,6 +6,6 @@ component = dmc.AreaChart(
     dataKey="date",
     data=data,
     withGradient=True,
-    series=[{"name": "Apples", "color": "var(--area-color)"}],
+    series=[{"name": "Apples", "color": "var(--chart-color)"}],
 )
 

--- a/docs/areachart/areacolor-light-dark.py
+++ b/docs/areachart/areacolor-light-dark.py
@@ -1,0 +1,13 @@
+import dash_mantine_components as dmc
+from .data import data
+
+
+
+component = dmc.AreaChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    withGradient=True,
+    series=[{"name": "Apples", "color": "var(--area-color)"}],
+)
+

--- a/docs/areachart/areacolor-light-dark.py
+++ b/docs/areachart/areacolor-light-dark.py
@@ -1,8 +1,6 @@
 import dash_mantine_components as dmc
 from .data import data
 
-
-
 component = dmc.AreaChart(
     h=300,
     dataKey="date",

--- a/docs/areachart/grid-text-color-light-dark.py
+++ b/docs/areachart/grid-text-color-light-dark.py
@@ -1,0 +1,15 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.AreaChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    type="stacked",
+    className="chart-grid-text-colors",
+    series=[
+        {"name": "Apples", "color": "indigo.6"},
+        {"name": "Oranges", "color": "blue.6"},
+        {"name": "Tomatoes", "color": "teal.6"},
+    ],
+)

--- a/docs/areachart/grid-text-color.py
+++ b/docs/areachart/grid-text-color.py
@@ -1,0 +1,16 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.AreaChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    type="stacked",
+    gridColor="gray.5",
+    textColor = "gray.9",
+    series=[
+        {"name": "Apples", "color": "indigo.6"},
+        {"name": "Oranges", "color": "blue.6"},
+        {"name": "Tomatoes", "color": "teal.6"},
+    ],
+)

--- a/docs/barchart/area-color-light-dark.py
+++ b/docs/barchart/area-color-light-dark.py
@@ -5,5 +5,5 @@ component = dmc.BarChart(
     h=300,
     dataKey="date",
     data=data,
-    series=[{"name": "Smartphones", "color": "var(--area-color)"}],
+    series=[{"name": "Smartphones", "color": "var(--chart-color)"}],
 )

--- a/docs/barchart/area-color-light-dark.py
+++ b/docs/barchart/area-color-light-dark.py
@@ -1,0 +1,9 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.BarChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    series=[{"name": "Smartphones", "color": "var(--area-color)"}],
+)

--- a/docs/barchart/barchart.md
+++ b/docs/barchart/barchart.md
@@ -166,7 +166,7 @@ Example of bar area color that is dark orange in light mode and lime in dark mod
     :code: false
 
 
-.. sourcetabs::docs/barchart/area-color-light-dark.py, assets/examples/area-color.css
+.. sourcetabs::docs/barchart/area-color-light-dark.py, assets/examples/chart-color.css
     :defaultExpanded: true
     :withExpandedButton: true
 
@@ -203,7 +203,7 @@ With CSS , you can change colors depending on color scheme.  Learn more in the T
     :defaultExpanded: true
     :withExpandedButton: true
 
-If your application has only one color scheme, you can use gridColor and textColor props instead of CSS variables:
+If your application has only one color scheme, you can use `gridColor` and `textColor` props instead of CSS variables:
 
 ```python
 dmc.BarChart(

--- a/docs/barchart/barchart.md
+++ b/docs/barchart/barchart.md
@@ -145,7 +145,7 @@ Any valid CSS color value is also accepted.
 import dash_mantine_components as dmc
 from .data import data
 
-dmc.AreaChart(
+dmc.BarChart(
     h=300,
     dataKey="date",
     data=data,
@@ -154,6 +154,22 @@ dmc.AreaChart(
 )
 
 ```
+
+
+### Change area color depending on color scheme
+You can use CSS variables in color property. Learn more in the Theming section under [Colors.](/colors#colors-in-light-and-dark-mode)
+
+Example of bar area color that is dark orange in light mode and lime in dark mode:
+
+
+.. exec::docs.barchart.area-color-light-dark
+    :code: false
+
+
+.. sourcetabs::docs/barchart/area-color-light-dark.py, assets/examples/area-color.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
 
 ### Bar props
 You can pass props down to recharts [Bar](https://recharts.org/en-US/api/Bar) component with `barProps` prop. `barProps` accepts an object with rechart props.
@@ -171,6 +187,39 @@ By default, the Recharts data animation is disabled. To enable and customize the
 Set `strokeDasharray` prop to control the stroke dash array of the grid and cursor lines. The value represent the lengths of alternating dashes and gaps. For example, strokeDasharray="10 5" will render a dashed line with 10px dashes and 5px gaps.
 
 .. exec::docs.barchart.strokedasharray
+
+
+### Grid and text colors
+Use `--chart-grid-color` and `--chart-text-color` to change colors of grid lines and text within the chart. 
+With CSS , you can change colors depending on color scheme.  Learn more in the Theming section under [Colors.](/colors#colors-in-light-and-dark-mode)
+
+
+
+.. exec::docs.barchart.grid-text-color-light-dark
+    :code: false
+
+
+.. sourcetabs::docs/barchart/grid-text-color-light-dark.py, assets/examples/chart-grid-text-colors.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+If your application has only one color scheme, you can use gridColor and textColor props instead of CSS variables:
+
+```python
+dmc.BarChart(
+    h=300,
+    dataKey="month",
+    data=data,
+    type="stacked",
+    gridColor="gray.5",
+    textColor = "gray.9",
+    series=[
+        {"name": "Smartphones", "color": "violet.6"},
+        {"name": "Laptops", "color": "blue.6"},
+        {"name": "Tablets", "color": "teal.6"},
+    ],
+)
+```
 
 ### Tooltip animation
 By default, tooltip animation is disabled. To enable it, set `tooltipAnimationDuration` prop to a number of milliseconds to animate the tooltip position change.

--- a/docs/barchart/grid-text-color-light-dark.py
+++ b/docs/barchart/grid-text-color-light-dark.py
@@ -1,0 +1,15 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.BarChart(
+    h=300,
+    dataKey="month",
+    data=data,
+    type="stacked",
+    className="chart-grid-text-colors",
+    series=[
+        {"name": "Smartphones", "color": "violet.6"},
+        {"name": "Laptops", "color": "blue.6"},
+        {"name": "Tablets", "color": "teal.6"},
+    ],
+)

--- a/docs/bubblechart/area-color-light-dark.py
+++ b/docs/bubblechart/area-color-light-dark.py
@@ -1,0 +1,11 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.BubbleChart(
+    h=60,
+    data=data,
+    range=[16, 225],
+    label="Sales/hour",
+    color="var(--area-color)",
+    dataKey={"x": "hour", "y": "index", "z": "value"}
+)

--- a/docs/bubblechart/area-color-light-dark.py
+++ b/docs/bubblechart/area-color-light-dark.py
@@ -6,6 +6,6 @@ component = dmc.BubbleChart(
     data=data,
     range=[16, 225],
     label="Sales/hour",
-    color="var(--area-color)",
+    color="var(--chart-color)",
     dataKey={"x": "hour", "y": "index", "z": "value"}
 )

--- a/docs/bubblechart/bubblechart.md
+++ b/docs/bubblechart/bubblechart.md
@@ -38,6 +38,51 @@ You can reference colors from theme the same way as in other components, for exa
 .. exec::docs.bubblechart.interactive
     :code: false
 
+
+### Change line color depending on color scheme
+You can use CSS variables in color property. Learn more in the Theming section under [Colors.](/colors#colors-in-light-and-dark-mode)
+
+Example of line color that is dark orange in light mode and lime in dark mode:
+
+
+.. exec::docs.bubblechart.area-color-light-dark
+    :code: false
+
+
+.. sourcetabs::docs/bubblechart/area-color-light-dark.py, assets/examples/area-color.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+
+
+### Grid and text colors
+Use `--chart-grid-color` and `--chart-text-color` to change colors of grid lines and text within the chart. 
+With CSS , you can change colors depending on color scheme.  Learn more in the Theming section under [Colors.](/colors#colors-in-light-and-dark-mode)
+
+.. exec::docs.bubblechart.grid-text-color-light-dark
+    :code: false
+
+
+.. sourcetabs::docs/bubblechart/grid-text-color-light-dark.py, assets/examples/chart-grid-text-colors.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+If your application has only one color scheme, you can use gridColor and textColor props instead of CSS variables:
+
+```python
+dmc.BubbleChart(
+    gridColor="gray.5",
+    textColor="gray.9",
+    h=60,
+    data=data,
+    range=[16, 225],
+    label="Sales/hour",
+    color="lime.6",
+    dataKey={"x": "hour", "y": "index", "z": "value"}
+)
+
+```
+
 ### Remove tooltip
 To remove tooltip, set `withTooltip=False`. It also removes the cursor line and disables interactions with the chart.
 

--- a/docs/bubblechart/bubblechart.md
+++ b/docs/bubblechart/bubblechart.md
@@ -49,7 +49,7 @@ Example of line color that is dark orange in light mode and lime in dark mode:
     :code: false
 
 
-.. sourcetabs::docs/bubblechart/area-color-light-dark.py, assets/examples/area-color.css
+.. sourcetabs::docs/bubblechart/area-color-light-dark.py, assets/examples/chart-color.css
     :defaultExpanded: true
     :withExpandedButton: true
 
@@ -67,7 +67,7 @@ With CSS , you can change colors depending on color scheme.  Learn more in the T
     :defaultExpanded: true
     :withExpandedButton: true
 
-If your application has only one color scheme, you can use gridColor and textColor props instead of CSS variables:
+If your application has only one color scheme, you can use `gridColor` and `textColor` props instead of CSS variables:
 
 ```python
 dmc.BubbleChart(

--- a/docs/bubblechart/grid-text-color-light-dark.py
+++ b/docs/bubblechart/grid-text-color-light-dark.py
@@ -1,0 +1,11 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.BubbleChart(
+    h=60,
+    data=data,
+    range=[16, 225],
+    label="Sales/hour",
+    className="chart-grid-text-colors",
+    dataKey={"x": "hour", "y": "index", "z": "value"}
+)

--- a/docs/compositechart/compositechart.md
+++ b/docs/compositechart/compositechart.md
@@ -133,10 +133,62 @@ You can reference colors from theme the same way as in other components, for exa
 
 .. exec::docs.compositechart.chartcolor
 
+
+
+### Change chart color depending on color scheme
+You can use CSS variables in color property. Learn more in the Theming section under [Colors.](/colors#colors-in-light-and-dark-mode)
+
+Example of line color that is dark orange in light mode and lime in dark mode:
+
+
+.. exec::docs.compositechart.line-color-light-dark
+    :code: false
+
+
+.. sourcetabs::docs/compositechart/line-color-light-dark.py, assets/examples/chart-color.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+
 ### Stroke dash array
 Set `strokeDasharray` prop to control the stroke dash array of the grid and cursor lines. The value represent the lengths of alternating dashes and gaps. For example, strokeDasharray="10 5" will render a dashed line with 10px dashes and 5px gaps.
 
 .. exec::docs.compositechart.strokedasharray
+
+
+
+### Grid and text colors
+Use `--chart-grid-color` and `--chart-text-color` to change colors of grid lines and text within the chart. 
+With CSS , you can change colors depending on color scheme.  Learn more in the Theming section under [Colors.](/colors#colors-in-light-and-dark-mode)
+
+.. exec::docs.compositechart.grid-text-color-light-dark
+    :code: false
+
+
+.. sourcetabs::docs/compositechart/grid-text-color-light-dark.py, assets/examples/chart-grid-text-colors.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+If your application has only one color scheme, you can use `gridColor` and `textColor` props instead of CSS variables:
+
+```python
+dmc.CompositeChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    maxBarWidth=30,
+    gridColor="gray.5",
+    textColor="gray.9",
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)
+
+```
+
+
 
 
 ### Tooltip animation

--- a/docs/compositechart/grid-text-color-light-dark.py
+++ b/docs/compositechart/grid-text-color-light-dark.py
@@ -1,0 +1,15 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    maxBarWidth=30,
+    className="chart-grid-text-colors",
+    series=[
+        {"name": "Tomatoes", "color": "rgba(18, 120, 255, 0.2)", "type": "bar"},
+        {"name": "Apples", "color": "red.8", "type": "line"},
+        {"name": "Oranges", "color": "yellow.8", "type": "area"},
+    ]
+)

--- a/docs/compositechart/line-color-light-dark.py
+++ b/docs/compositechart/line-color-light-dark.py
@@ -1,0 +1,10 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.CompositeChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    series=[{"name": "Apples", "color": "var(--chart-color)", "type": "line" }],
+)
+

--- a/docs/linechart/grid-text-color-light-dark.py
+++ b/docs/linechart/grid-text-color-light-dark.py
@@ -1,0 +1,17 @@
+import dash_mantine_components as dmc
+from .data import data
+
+
+
+component = dmc.LineChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    className="chart-grid-text-colors",
+    series=[
+        {"name": "Apples", "color": "indigo.6"},
+        {"name": "Oranges", "color": "blue.6"},
+        {"name": "Tomatoes", "color": "teal.6"},
+    ],
+)
+

--- a/docs/linechart/line-color-light-dark.py
+++ b/docs/linechart/line-color-light-dark.py
@@ -1,0 +1,9 @@
+import dash_mantine_components as dmc
+from .data import data
+
+component = dmc.LineChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    series=[{"name": "Apples", "color": "var(--area-color)"}],
+)

--- a/docs/linechart/line-color-light-dark.py
+++ b/docs/linechart/line-color-light-dark.py
@@ -5,5 +5,5 @@ component = dmc.LineChart(
     h=300,
     dataKey="date",
     data=data,
-    series=[{"name": "Apples", "color": "var(--area-color)"}],
+    series=[{"name": "Apples", "color": "var(--chart-color)"}],
 )

--- a/docs/linechart/line.md
+++ b/docs/linechart/line.md
@@ -159,7 +159,7 @@ Example of line color that is dark orange in light mode and lime in dark mode:
     :code: false
 
 
-.. sourcetabs::docs/linechart/line-color-light-dark.py, assets/examples/area-color.css
+.. sourcetabs::docs/linechart/line-color-light-dark.py, assets/examples/chart-color.css
     :defaultExpanded: true
     :withExpandedButton: true
 
@@ -189,7 +189,7 @@ With CSS , you can change colors depending on color scheme.  Learn more in the T
     :defaultExpanded: true
     :withExpandedButton: true
 
-If your application has only one color scheme, you can use gridColor and textColor props instead of CSS variables:
+If your application has only one color scheme, you can use `gridColor` and `textColor` props instead of CSS variables:
 
 ```python
 dmc.LineChart(

--- a/docs/linechart/line.md
+++ b/docs/linechart/line.md
@@ -149,6 +149,22 @@ Any valid CSS color value is also accepted.
 
 .. exec::docs.linechart.linecolor
 
+### Change line color depending on color scheme
+You can use CSS variables in color property. Learn more in the Theming section under [Colors.](/colors#colors-in-light-and-dark-mode)
+
+Example of line color that is dark orange in light mode and lime in dark mode:
+
+
+.. exec::docs.linechart.line-color-light-dark
+    :code: false
+
+
+.. sourcetabs::docs/linechart/line-color-light-dark.py, assets/examples/area-color.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+
+
 ### Stroke dash array
 Set `strokeDasharray` prop to control the stroke dash array of the grid and cursor lines. The value represent the
 lengths of alternating dashes and gaps. For example, strokeDasharray="10 5" will render a dashed line with 10px dashes
@@ -156,6 +172,40 @@ and 5px gaps.
 
 
 .. exec::docs.linechart.strokedasharray
+
+
+
+### Grid and text colors
+Use `--chart-grid-color` and `--chart-text-color` to change colors of grid lines and text within the chart. 
+With CSS , you can change colors depending on color scheme.  Learn more in the Theming section under [Colors.](/colors#colors-in-light-and-dark-mode)
+
+
+
+.. exec::docs.linechart.grid-text-color-light-dark
+    :code: false
+
+
+.. sourcetabs::docs/linechart/grid-text-color-light-dark.py, assets/examples/chart-grid-text-colors.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+If your application has only one color scheme, you can use gridColor and textColor props instead of CSS variables:
+
+```python
+dmc.LineChart(
+    h=300,
+    dataKey="date",
+    data=data,
+    gridColor="gray.5",
+    textColor = "gray.9",
+    series=[
+        {"name": "Apples", "color": "indigo.6"},
+        {"name": "Oranges", "color": "blue.6"},
+        {"name": "Tomatoes", "color": "teal.6"},
+    ],
+)
+
+```
 
 ### Tooltip animation
 By default, tooltip animation is disabled. To enable it, set `tooltipAnimationDuration` prop to a number of

--- a/docs/scatterchart/grid-text-color-light-dark.py
+++ b/docs/scatterchart/grid-text-color-light-dark.py
@@ -1,0 +1,13 @@
+import dash_mantine_components as dmc
+
+from .data import data1
+
+component = dmc.ScatterChart(
+    h=300,
+    data=data1,
+    dataKey={"x": "age", "y": "BMI"},
+    tickLine="xy",
+    xAxisLabel="Age",
+    yAxisLabel="BMI",
+    className="chart-grid-text-colors",
+)

--- a/docs/scatterchart/scatter.md
+++ b/docs/scatterchart/scatter.md
@@ -181,6 +181,38 @@ and 5px gaps.
 
 .. exec::docs.scatterchart.strokedasharray
 
+
+### Grid and text colors
+Use `--chart-grid-color` and `--chart-text-color` to change colors of grid lines and text within the chart. 
+With CSS , you can change colors depending on color scheme.  Learn more in the Theming section under [Colors.](/colors#colors-in-light-and-dark-mode)
+
+
+
+.. exec::docs.scatterchart.grid-text-color-light-dark
+    :code: false
+
+
+.. sourcetabs::docs/scatterchart/grid-text-color-light-dark.py, assets/examples/chart-grid-text-colors.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+If your application has only one color scheme, you can use `gridColor` and `textColor` props instead of CSS variables:
+
+```python
+
+dmc.ScatterChart(
+    h=300,
+    data=data1,
+    dataKey={"x": "age", "y": "BMI"},
+    tickLine="xy",
+    xAxisLabel="Age",
+    yAxisLabel="BMI",
+    gridColor="gray.5",
+    textColor = "gray.9",
+)
+
+```
+
 ### Units
 Set `unit` prop to render a unit label next to the y-axis ticks and tooltip values:
 

--- a/docs/sparkline/areacolor-light-dark.py
+++ b/docs/sparkline/areacolor-light-dark.py
@@ -1,0 +1,3 @@
+import dash_mantine_components as dmc
+
+component = dmc.Sparkline(w=200, h=60, data=[10, 20, 40, 20, 40, 10, 50], className="chart-color")

--- a/docs/sparkline/spark_animation.py
+++ b/docs/sparkline/spark_animation.py
@@ -9,6 +9,7 @@ component = dmc.Box(
             h=60,
             data=[],
             areaProps={"isAnimationActive": True},
+            color="blue",
             id="spark-animation",
         ),
     ]

--- a/docs/sparkline/sparkline.md
+++ b/docs/sparkline/sparkline.md
@@ -46,6 +46,21 @@ Use `trendColors` prop instead of `color` to change chart color depending on the
 .. exec::docs.sparkline.trendcolors
 
 
+### Change area color depending on color scheme
+You can use CSS variables in color property. Learn more in the Theming section under [Colors.](/colors#colors-in-light-and-dark-mode)
+
+Example of area color that is dark orange in light mode and lime in dark mode:
+
+
+.. exec::docs.sparkline.areacolor-light-dark
+    :code: false
+
+
+.. sourcetabs::docs/sparkline/areacolor-light-dark.py, assets/examples/chart-color.css
+    :defaultExpanded: true
+    :withExpandedButton: true
+
+
 ### Sparkline animation
 By default, the Recharts data animation is disabled. To enable and customize the animation, use `areaProps` to pass properties to the Recharts `Area` component.
 


### PR DESCRIPTION
Add examples of styling the chart, grid and text colors based on light or dark color scheme for each chart type.