### PR TITLE
Documentation fix for the `Loader` component

### DIFF
--- a/docs/loader/loader.md
+++ b/docs/loader/loader.md
@@ -17,7 +17,7 @@ category: Feedback
 Loader component supports 3 types of loaders: `oval`, `bars` and `dots` by default. All loaders are animated with CSS for better performance.
 
 By default, Loader will be rendered with theme.primaryColor. A Loader can be customized with `color`, `size`, and
-`variant` props.
+`type` props.
 
 .. exec::docs.loader.simple
 

--- a/docs/loader/simple.py
+++ b/docs/loader/simple.py
@@ -1,3 +1,3 @@
 import dash_mantine_components as dmc
 
-component = dmc.Loader(color="red", size="md", variant="oval")
+component = dmc.Loader(color="red", size="md", type="oval")


### PR DESCRIPTION
Little fix about the usage of `type` instead of `variant` for `Loader`