### PR TITLE
:memo: fix typo for mantine figure template

### DIFF
--- a/docs/figuretemplates/mantine_figure_templates.py
+++ b/docs/figuretemplates/mantine_figure_templates.py
@@ -10,7 +10,7 @@ dmc.add_figure_templates()
 
 component = dmc.SimpleGrid(
     [
-        dcc.Graph(figure=px.bar(dff, x="continent", y="pop", template="mantine_light", title="matine_light theme" )),
+        dcc.Graph(figure=px.bar(dff, x="continent", y="pop", template="mantine_light", title="mantine_light theme" )),
         dcc.Graph(figure=px.bar(dff, x="continent", y="pop", template="mantine_dark",  title="mantine_dark theme"))
     ],
     cols=2


### PR DESCRIPTION
This fixes the typo in the https://www.dash-mantine-components.com/components/figure-templates documentation

<img width="1039" height="782" alt="mantine-figure-template-typo" src="https://github.com/user-attachments/assets/64285c1a-46fa-4545-86ee-d5f8b022f529" />
