### PR TITLE
fix: encoding errors when parsing

### DIFF
--- a/lib/directives/source.py
+++ b/lib/directives/source.py
@@ -28,7 +28,7 @@ class SC(SourceCode):
             code.append(
                 {
                     "fileName": os.path.basename(file),
-                    "code": open(file, "r").read(),
+                    "code": open(file, "r", encoding="utf-8").read(),
                     "language": mapping[extension]["language"],
                     "icon": mapping[extension]["icon"],
                 }

--- a/pages/markdown.py
+++ b/pages/markdown.py
@@ -44,7 +44,7 @@ parse = create_parser(directives)
 
 for file in files:
     logger.info("Loading %s..", file)
-    metadata, content = frontmatter.parse(file.read_text())
+    metadata, content = frontmatter.parse(file.read_text(encoding="utf-8"))
     metadata = Meta(**metadata)
     layout = parse(content)
 


### PR DESCRIPTION
Fix errors like the following by setting the encoding to utf-8
> UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1397: character maps to <undefined>